### PR TITLE
Adding `abi_stable` support for `tremor-runtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,15 +11,17 @@ dependencies = [
  "abi_stable_derive",
  "abi_stable_shared",
  "core_extensions",
+ "crossbeam-channel",
  "generational-arena",
  "libloading",
- "lock_api 0.4.5",
- "parking_lot 0.11.2",
+ "lock_api",
+ "parking_lot",
  "paste",
  "repr_offset",
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -32,9 +34,9 @@ dependencies = [
  "as_derive_utils",
  "core_extensions",
  "proc-macro2",
- "quote 1.0.10",
+ "quote",
  "rustc_version 0.2.3",
- "syn 1.0.81",
+ "syn",
  "typed-arena",
 ]
 
@@ -149,52 +151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "amq-protocol"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b51c409a2b30e48826a593d56a26a43f37bf3df682821e55cd108e24de9ce7"
-dependencies = [
- "amq-protocol-tcp",
- "amq-protocol-types",
- "amq-protocol-uri",
- "cookie-factory",
- "nom 7.0.0",
-]
-
-[[package]]
-name = "amq-protocol-tcp"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9797cd3a8f1491e4828818341aea5e1378029ec89dc2422cd85d62715f913080"
-dependencies = [
- "amq-protocol-uri",
- "tcp-stream",
- "tracing",
-]
-
-[[package]]
-name = "amq-protocol-types"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028cb766932137535fe8a320245e385bac379506d7e9e3d0375be069bb6fb0de"
-dependencies = [
- "cookie-factory",
- "nom 7.0.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "amq-protocol-uri"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08059afa9495f674408891c5eaee50c5eca3532598c90532c1856990b91da96"
-dependencies = [
- "percent-encoding 2.1.0",
- "url 2.2.2",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,8 +200,8 @@ checksum = "e0a26fa495cefb8c86d9ce183b3f39ad11678e54fb3c20e6b7dbd87770811d9b"
 dependencies = [
  "core_extensions",
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -263,8 +219,8 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -341,17 +297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3ca4f8ff117c37c278a2f7415ce9be55560b846b5bc4412aaa5d29c1c3dae2"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
 name = "async-global-executor"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,7 +329,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "log",
- "pin-project 1.0.8",
+ "pin-project",
 ]
 
 [[package]]
@@ -422,27 +367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-nats"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dae854440faecce70f0664f41f09a588de1e7a4366931ec3962ded3d8f903c5"
-dependencies = [
- "blocking",
- "nats",
-]
-
-[[package]]
-name = "async-net"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5373304df79b9b4395068fb080369ec7178608827306ce4d081cba51cac551df"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
 ]
 
 [[package]]
@@ -509,7 +433,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-process",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -524,20 +448,6 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-std-resolver"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4e2c3da14d8ad45acb1e3191db7a918e9505b6f155b218e70a7c9a1a48c638"
-dependencies = [
- "async-std",
- "async-trait",
- "futures-io",
- "futures-util",
- "pin-utils",
- "trust-dns-resolver",
 ]
 
 [[package]]
@@ -557,8 +467,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -568,57 +478,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
-name = "async-tls"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
-dependencies = [
- "futures-core",
- "futures-io",
- "rustls 0.19.1",
- "webpki",
- "webpki-roots 0.21.1",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
-]
-
-[[package]]
-name = "async-tungstenite"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7cc5408453d37e2b1c6f01d8078af1da58b6cfa6a80fa2ede3bd2b9a6ada9c4"
-dependencies = [
- "futures-io",
- "futures-util",
- "log",
- "pin-project 1.0.8",
- "tokio 1.12.0",
- "tokio-rustls",
- "tungstenite 0.11.1",
- "webpki-roots 0.20.0",
-]
-
-[[package]]
-name = "async-tungstenite"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8645e929ec7964448a901db9da30cd2ae8c7fecf4d6176af427837531dbbb63b"
-dependencies = [
- "async-std",
- "futures-io",
- "futures-util",
- "log",
- "pin-project-lite 0.2.7",
- "tungstenite 0.13.0",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -626,36 +493,6 @@ name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
-
-[[package]]
-name = "attohttpc"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe174d1b67f7b2bafed829c09db039301eb5841f66e43be2cf60b326e7f8e2cc"
-dependencies = [
- "flate2",
- "http 0.2.5",
- "log",
- "url 2.2.2",
-]
-
-[[package]]
-name = "attohttpc"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8bda305457262b339322106c776e3fd21df860018e566eb6a5b1aa4b6ae02d"
-dependencies = [
- "flate2",
- "http 0.2.5",
- "log",
- "rustls 0.18.1",
- "serde",
- "serde_urlencoded 0.6.1",
- "url 2.2.2",
- "webpki",
- "webpki-roots 0.19.0",
- "wildmatch",
-]
 
 [[package]]
 name = "atty"
@@ -667,12 +504,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -703,15 +534,6 @@ checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -721,15 +543,6 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
-name = "base64-url"
-version = "1.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44265cf903f576fcaa1c2f23b32ec2dadaa8ec9d6b7c6212704d72a417bfbeef"
-dependencies = [
- "base64 0.13.0",
-]
 
 [[package]]
 name = "beef"
@@ -771,7 +584,7 @@ dependencies = [
  "log",
  "peeking_take_while",
  "proc-macro2",
- "quote 1.0.10",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
@@ -861,7 +674,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c7230ddbb427b1094d477d821a99f3f54d36333178eeb806e279bcdcecf0ca"
 dependencies = [
- "crossbeam-queue 0.3.2",
+ "crossbeam-queue",
  "stable_deref_trait",
 ]
 
@@ -870,17 +683,6 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "either",
- "iovec",
-]
 
 [[package]]
 name = "bytes"
@@ -933,7 +735,7 @@ dependencies = [
  "indicatif",
  "log",
  "rand 0.7.3",
- "reqwest 0.10.10",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -1004,7 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e2c74943a630a8e7e830bca4974b47263ef86646d52b573b4b77d957c806e51"
 dependencies = [
  "debug-helper",
- "num-bigint 0.4.2",
+ "num-bigint",
  "num-traits",
  "once_cell",
  "regex",
@@ -1073,8 +875,8 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1084,15 +886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9b1abef93569f290952eff3c4a0a92d6767bb5158db095b4dc9a512b1c3643"
 dependencies = [
  "clap 3.0.0-beta.4",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1161,16 +954,6 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
-dependencies = [
- "time 0.1.43",
- "url 1.7.2",
-]
-
-[[package]]
-name = "cookie"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
@@ -1179,35 +962,11 @@ dependencies = [
  "base64 0.13.0",
  "hkdf",
  "hmac 0.10.1",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "rand 0.8.4",
  "sha2",
  "time 0.2.27",
  "version_check",
-]
-
-[[package]]
-name = "cookie-factory"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
-
-[[package]]
-name = "cookie_store"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
-dependencies = [
- "cookie 0.12.0",
- "failure",
- "idna 0.1.5",
- "log",
- "publicsuffix",
- "serde",
- "serde_json",
- "time 0.1.43",
- "try_from",
- "url 1.7.2",
 ]
 
 [[package]]
@@ -1302,44 +1061,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cron"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e009ed0b762cf7a967a34dfdc67d5967d3f828f12901d37081432c3dd1668f8f"
-dependencies = [
- "chrono",
- "nom 4.1.1",
- "once_cell",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
-dependencies = [
- "crossbeam-utils 0.6.6",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
-dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1349,23 +1077,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.5",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "lazy_static",
- "maybe-uninit",
- "memoffset 0.5.6",
- "scopeguard",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1375,21 +1088,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
  "lazy_static",
- "memoffset 0.6.4",
+ "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -1399,28 +1101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
-dependencies = [
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "lazy_static",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1460,16 +1141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,8 +1168,8 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1542,19 +1213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,12 +1221,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "debug-helper"
@@ -1583,8 +1235,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1672,12 +1324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9d8664cf849d7d0f3114a3a387d2f5e4303176d746d5a951aaddc66dfe9240"
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,78 +1342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd4afd79212583ff429b913ad6605242ed7eec277e950b1438f300748f948f4"
 
 [[package]]
-name = "ed25519"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
-dependencies = [
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "sha2",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "elastic"
-version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea64ae42acdc36a016c5d7315189f573f60b23dcbf3b0d6b0460ff72cdf1071d"
-dependencies = [
- "bytes 0.4.12",
- "chrono",
- "crossbeam-channel 0.3.9",
- "elastic_derive",
- "error-chain 0.11.0",
- "fluent_builder",
- "futures 0.1.31",
- "geo",
- "geohash",
- "geojson",
- "http 0.1.21",
- "log",
- "quick-error 1.2.3",
- "reqwest 0.9.24",
- "serde",
- "serde_derive",
- "serde_json",
- "tokio 0.1.22",
- "tokio-threadpool",
- "url 1.7.2",
- "uuid 0.6.5",
-]
-
-[[package]]
-name = "elastic_derive"
-version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b385d447741a87d519e38e63b7606a2bfa46957135ebdd89754c1e7ec57005"
-dependencies = [
- "chrono",
- "nom 2.2.1",
- "quick-error 1.2.3",
- "quote 0.3.15",
- "serde",
- "serde_derive_internals",
- "serde_json",
- "syn 0.11.11",
 ]
 
 [[package]]
@@ -1795,18 +1375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,15 +1398,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -1874,16 +1433,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
  "synstructure",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -1956,12 +1509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluent_builder"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d86fdb1e69d4656dddde580b446329f14946c52fa1aa3057c3e72133bbac97"
-
-[[package]]
 name = "flume"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,7 +1547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2012,12 +1559,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -2034,12 +1575,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -2071,16 +1606,6 @@ name = "futures-core"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
-
-[[package]]
-name = "futures-cpupool"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-dependencies = [
- "futures 0.1.31",
- "num_cpus",
-]
 
 [[package]]
 name = "futures-executor"
@@ -2120,11 +1645,11 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2140,18 +1665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-
-[[package]]
 name = "futures-util"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -2167,35 +1686,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures_codec"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.17",
- "memchr",
- "pin-project 0.4.28",
-]
-
-[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "gcemeta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b740806c16b381ca8d78cb3869fb47ce5b490db28c5f19bc0336a9b9aaca6e"
-dependencies = [
- "attohttpc 0.15.0",
- "lazy_static",
- "serde_json",
 ]
 
 [[package]]
@@ -2215,49 +1711,6 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "geo"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ce8faa25a6f5ce8ea98faa95247d66377a843408eb4418332ec37de96850b0"
-dependencies = [
- "failure",
- "geo-types",
- "num-traits",
- "rstar",
-]
-
-[[package]]
-name = "geo-types"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866e8f6dbd2218b05ea8a25daa1bfac32b0515fe7e0a37cb6a7b9ed0ed82a07e"
-dependencies = [
- "num-traits",
- "rstar",
-]
-
-[[package]]
-name = "geohash"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c97316dbd08e58b49c9f0ab5d37aeca27059065b86b360506ea484bd74b286"
-dependencies = [
- "failure",
- "geo-types",
-]
-
-[[package]]
-name = "geojson"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b37e57c7f498be81360116a489ebad0b133557e87d8b4f82d51bebd1c3ef9e"
-dependencies = [
- "num-traits",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2351,31 +1804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "googapis"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8894a4cb9b32a73030f2c2dd6a251114d5ec62fb786d011850ae98cdfb8d2ff2"
-dependencies = [
- "prost",
- "prost-types",
- "tonic",
-]
-
-[[package]]
-name = "gouth"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c138d157085ba4eb1aaa86e622dc348b956d5ac9d2e446b65941467ebffefdd6"
-dependencies = [
- "attohttpc 0.17.0",
- "gcemeta",
- "jsonwebtoken",
- "serde",
- "serde_json",
- "url 2.2.2",
-]
-
-[[package]]
 name = "grok"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,24 +1811,6 @@ checksum = "840fbb5c3bf23c11b93fbccddb9e93e79d2eab3e21f0e111bff1793928602670"
 dependencies = [
  "glob",
  "onig",
-]
-
-[[package]]
-name = "h2"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
-dependencies = [
- "byteorder",
- "bytes 0.4.12",
- "fnv",
- "futures 0.1.31",
- "http 0.1.21",
- "indexmap",
- "log",
- "slab",
- "string",
- "tokio-io",
 ]
 
 [[package]]
@@ -2414,7 +1824,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.5",
+ "http",
  "indexmap",
  "slab",
  "tokio 0.2.25",
@@ -2434,7 +1844,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.5",
+ "http",
  "indexmap",
  "slab",
  "tokio 1.12.0",
@@ -2466,7 +1876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
 dependencies = [
  "ahash 0.3.8",
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -2487,7 +1897,7 @@ checksum = "6490be71f07a5f62b564bc58e36953f675833df11c7e4a0647bee7a07ca1ec5e"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "crossbeam-channel 0.5.1",
+ "crossbeam-channel",
  "flate2",
  "nom 7.0.0",
  "num-traits",
@@ -2548,16 +1958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac 0.11.1",
- "digest",
-]
-
-[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,17 +1966,6 @@ dependencies = [
  "libc",
  "match_cfg",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "http"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
-dependencies = [
- "bytes 0.4.12",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -2592,24 +1981,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "http 0.1.21",
- "tokio-buf",
-]
-
-[[package]]
-name = "http-body"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
  "bytes 0.5.6",
- "http 0.2.5",
+ "http",
 ]
 
 [[package]]
@@ -2619,7 +1996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
- "http 0.2.5",
+ "http",
  "pin-project-lite 0.2.7",
 ]
 
@@ -2648,7 +2025,7 @@ dependencies = [
  "async-channel",
  "async-std",
  "base64 0.13.0",
- "cookie 0.14.4",
+ "cookie",
  "futures-lite",
  "infer",
  "pin-project-lite 0.2.7",
@@ -2656,8 +2033,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "serde_urlencoded 0.7.0",
- "url 2.2.2",
+ "serde_urlencoded",
+ "url",
 ]
 
 [[package]]
@@ -2686,36 +2063,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.12.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c843caf6296fc1f93444735205af9ed4e109a539005abb2564ae1d6fad34c52"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "futures-cpupool",
- "h2 0.1.26",
- "http 0.1.21",
- "http-body 0.1.0",
- "httparse",
- "iovec",
- "itoa",
- "log",
- "net2",
- "rustc_version 0.2.3",
- "time 0.1.43",
- "tokio 0.1.22",
- "tokio-buf",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
- "want 0.2.0",
-]
-
-[[package]]
-name = "hyper"
 version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
@@ -2725,17 +2072,17 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.2.7",
- "http 0.2.5",
+ "http",
  "http-body 0.3.1",
  "httparse",
  "httpdate 0.3.2",
  "itoa",
- "pin-project 1.0.8",
+ "pin-project",
  "socket2 0.3.19",
  "tokio 0.2.25",
  "tower-service",
  "tracing",
- "want 0.3.0",
+ "want",
 ]
 
 [[package]]
@@ -2749,7 +2096,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.3.7",
- "http 0.2.5",
+ "http",
  "http-body 0.4.4",
  "httparse",
  "httpdate 1.0.1",
@@ -2759,22 +2106,7 @@ dependencies = [
  "tokio 1.12.0",
  "tower-service",
  "tracing",
- "want 0.3.0",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "futures-util",
- "hyper 0.14.14",
- "log",
- "rustls 0.19.1",
- "tokio 1.12.0",
- "tokio-rustls",
- "webpki",
+ "want",
 ]
 
 [[package]]
@@ -2803,30 +2135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes 1.1.0",
- "hyper 0.14.14",
- "native-tls",
- "tokio 1.12.0",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,7 +2151,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
 dependencies = [
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -2861,7 +2169,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown 0.11.2",
  "serde",
 ]
@@ -2885,24 +2193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
-name = "input_buffer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
-dependencies = [
- "bytes 0.5.6",
-]
-
-[[package]]
-name = "input_buffer"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
-dependencies = [
- "bytes 1.1.0",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,18 +2211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
-dependencies = [
- "socket2 0.3.19",
- "widestring",
- "winapi 0.3.9",
- "winreg 0.6.2",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,19 +2223,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2948a0ce43e2c2ef11d7edf6816508998d99e13badd1150be0914205df9388a"
 dependencies = [
  "bytes 0.5.6",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
  "curl",
  "curl-sys",
  "flume",
  "futures-lite",
- "http 0.2.5",
+ "http",
  "log",
  "once_cell",
  "slab",
  "sluice",
  "tracing",
  "tracing-futures",
- "url 2.2.2",
+ "url",
  "waker-fn",
 ]
 
@@ -3013,26 +2291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
-name = "jsonwebtoken"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
-dependencies = [
- "base64 0.12.3",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "jumphash"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,7 +2339,7 @@ dependencies = [
  "string_cache",
  "term",
  "tiny-keccak",
- "unicode-xid 0.2.2",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3091,23 +2349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e58cce361efcc90ba8a0a5f982c741ff86b603495bb15a998412e957dcd278"
 dependencies = [
  "regex",
-]
-
-[[package]]
-name = "lapin"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9415085ce81a4290b36c73c03307ce2477b62fa45fba8a80a7f776837f950b74"
-dependencies = [
- "amq-protocol",
- "async-task",
- "crossbeam-channel 0.5.1",
- "futures-core",
- "log",
- "mio 0.7.14",
- "parking_lot 0.11.2",
- "pinky-swear",
- "serde",
 ]
 
 [[package]]
@@ -3211,15 +2452,6 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
@@ -3259,7 +2491,7 @@ dependencies = [
  "libc",
  "log",
  "log-mdc",
- "parking_lot 0.11.2",
+ "parking_lot",
  "regex",
  "serde",
  "serde-value",
@@ -3278,15 +2510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
 dependencies = [
  "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -3352,23 +2575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
-name = "md-5"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
-dependencies = [
- "block-buffer",
- "digest",
- "opaque-debug",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,20 +2582,11 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg 1.0.1",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -3421,7 +2618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -3454,17 +2651,6 @@ dependencies = [
  "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
 ]
 
 [[package]]
@@ -3513,32 +2699,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nats"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0cfa3903c3e613edddaa4a2f86b2053a1d6fbcf315a3ff352c25ba9f0a8585"
-dependencies = [
- "base64 0.13.0",
- "base64-url",
- "crossbeam-channel 0.5.1",
- "fastrand",
- "itoa",
- "json",
- "libc",
- "log",
- "memchr",
- "nkeys",
- "nuid",
- "once_cell",
- "parking_lot 0.11.2",
- "regex",
- "rustls 0.19.1",
- "rustls-native-certs",
- "webpki",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,35 +2727,6 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
-name = "nkeys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a98f0a974ff737974b57ba1c71d2e0fe7ec18e5a828d4b8e02683171349dfa"
-dependencies = [
- "byteorder",
- "data-encoding",
- "ed25519-dalek",
- "log",
- "rand 0.7.3",
- "signatory",
-]
-
-[[package]]
-name = "nom"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
-
-[[package]]
-name = "nom"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c349f68f25f596b9f44cf0e7c69752a5c633b0550c3ff849518bfba0233774a"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "nom"
@@ -3628,33 +2759,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nuid"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7000c9392b545c4ba43e8abc086bf7d01cd2948690934c16980170b0549a2bd3"
-dependencies = [
- "lazy_static",
- "rand 0.8.4",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg 1.0.1",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3665,7 +2775,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
@@ -3675,7 +2785,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
@@ -3685,7 +2795,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -3696,28 +2806,6 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
-dependencies = [
- "derivative",
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
 ]
 
 [[package]]
@@ -3797,24 +2885,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
-name = "openssl-src"
-version = "111.16.0+1.1.1l"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3851,39 +2929,13 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.2",
- "rustc_version 0.2.3",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.5",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "rustc_version 0.2.3",
- "smallvec 0.6.14",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3896,7 +2948,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.10",
- "smallvec 1.7.0",
+ "smallvec",
  "winapi 0.3.9",
 ]
 
@@ -3907,33 +2959,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
-name = "pdqselect"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
-name = "pem"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
-dependencies = [
- "base64 0.13.0",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -3962,28 +2991,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fc3db1018c4b59d7d582a739436478b6035138b6aecbce989fc91c3e98409f"
-dependencies = [
- "phf_shared 0.10.0",
-]
-
-[[package]]
 name = "phf_shared"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
@@ -3996,31 +3007,11 @@ checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
-version = "0.4.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
-dependencies = [
- "pin-project-internal 0.4.28",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
- "pin-project-internal 1.0.8",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
-dependencies = [
- "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -4030,8 +3021,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4051,17 +3042,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pinky-swear"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf8cda6f8e1500338634e4e3ce90ac59eb7929a1e088b6946c742be1cc44dc1"
-dependencies = [
- "doc-comment",
- "parking_lot 0.11.2",
- "tracing",
-]
 
 [[package]]
 name = "pkg-config"
@@ -4128,52 +3108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325a6d2ac5dee293c3b2612d4993b98aec1dff096b0a2dae70ed7d95784a05da"
 
 [[package]]
-name = "postgres"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb76d6535496f633fa799bb872ffb4790e9cbdedda9d35564ca0252f930c0dd5"
-dependencies = [
- "bytes 1.1.0",
- "fallible-iterator",
- "futures 0.3.17",
- "log",
- "tokio 1.12.0",
- "tokio-postgres",
-]
-
-[[package]]
-name = "postgres-protocol"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b145e6a4ed52cb316a27787fc20fe8a25221cb476479f61e4e0327c15b98d91a"
-dependencies = [
- "base64 0.13.0",
- "byteorder",
- "bytes 1.1.0",
- "fallible-iterator",
- "hmac 0.11.0",
- "md-5",
- "memchr",
- "rand 0.8.4",
- "sha2",
- "stringprep",
-]
-
-[[package]]
-name = "postgres-types"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04619f94ba0cc80999f4fc7073607cb825bc739a883cb6d20900fc5e009d6b0d"
-dependencies = [
- "bytes 1.1.0",
- "chrono",
- "fallible-iterator",
- "postgres-protocol",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,16 +3132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
-dependencies = [
- "thiserror",
- "toml",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,8 +3139,8 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -4227,7 +3151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
+ "quote",
  "version_check",
 ]
 
@@ -4249,7 +3173,7 @@ version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4266,7 +3190,7 @@ dependencies = [
  "quick-error 2.0.1",
  "rand 0.8.4",
  "rand_chacha 0.3.1",
- "rand_xorshift 0.3.0",
+ "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
@@ -4309,8 +3233,8 @@ dependencies = [
  "anyhow",
  "itertools 0.10.1",
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4330,16 +3254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb14183cc7f213ee2410067e1ceeadba2a7478a59432ff0747a335202798b1e2"
 
 [[package]]
-name = "publicsuffix"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4ce31ff0a27d93c8de1849cf58162283752f065a90d508f1105fa6c9a213f"
-dependencies = [
- "idna 0.2.3",
- "url 2.2.2",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4353,49 +3267,11 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-
-[[package]]
-name = "quote"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift 0.1.1",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4425,16 +3301,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
@@ -4452,21 +3318,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -4488,15 +3339,6 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
@@ -4511,59 +3353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4587,8 +3376,8 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg 1.0.1",
- "crossbeam-deque 0.8.1",
+ "autocfg",
+ "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -4599,49 +3388,11 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
- "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.1",
- "crossbeam-utils 0.8.5",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdkafka"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af78bc431a82ef178c4ad6db537eb9cc25715a8591d27acc30455ee7227a76f4"
-dependencies = [
- "futures 0.3.17",
- "libc",
- "log",
- "rdkafka-sys",
- "serde",
- "serde_derive",
- "serde_json",
- "slab",
-]
-
-[[package]]
-name = "rdkafka-sys"
-version = "4.1.0+1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e212ccf56a2d4e0b9f874a1cad295495769e0cdbabe60e02b4f654d369a2d6a1"
-dependencies = [
- "cmake",
- "libc",
- "libz-sys",
- "num_enum",
- "pkg-config",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4702,65 +3453,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rental"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc89fe2acac36d212474d138aaf939c04a82df5b61d07011571ebce5aef81f2e"
-dependencies = [
- "rental-impl",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "rental-impl"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
-dependencies = [
- "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
-]
-
-[[package]]
 name = "repr_offset"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "663e92f38214b9e51fa305902788f5fb45fb60027b727556618fc53ba1946112"
 dependencies = [
  "tstr",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.9.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
-dependencies = [
- "base64 0.10.1",
- "bytes 0.4.12",
- "cookie 0.12.0",
- "cookie_store",
- "encoding_rs",
- "flate2",
- "futures 0.1.31",
- "http 0.1.21",
- "hyper 0.12.36",
- "log",
- "mime",
- "mime_guess",
- "serde",
- "serde_json",
- "serde_urlencoded 0.5.5",
- "time 0.1.43",
- "tokio 0.1.22",
- "tokio-executor",
- "tokio-io",
- "tokio-threadpool",
- "tokio-timer",
- "url 1.7.2",
- "uuid 0.7.4",
- "winreg 0.6.2",
 ]
 
 [[package]]
@@ -4774,10 +3472,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.5",
+ "http",
  "http-body 0.3.1",
  "hyper 0.13.10",
- "hyper-tls 0.4.3",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -4785,67 +3483,17 @@ dependencies = [
  "mime",
  "mime_guess",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite 0.2.7",
  "serde",
- "serde_urlencoded 0.7.0",
+ "serde_urlencoded",
  "tokio 0.2.25",
  "tokio-tls",
- "url 2.2.2",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.7.0",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
-dependencies = [
- "base64 0.13.0",
- "bytes 1.1.0",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "http 0.2.5",
- "http-body 0.4.4",
- "hyper 0.14.14",
- "hyper-rustls",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "lazy_static",
- "log",
- "mime",
- "mime_guess",
- "native-tls",
- "percent-encoding 2.1.0",
- "pin-project-lite 0.2.7",
- "rustls 0.19.1",
- "serde",
- "serde_json",
- "serde_urlencoded 0.7.0",
- "tokio 1.12.0",
- "tokio-native-tls",
- "tokio-rustls",
- "url 2.2.2",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.21.1",
- "winreg 0.7.0",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error 1.2.3",
+ "winreg",
 ]
 
 [[package]]
@@ -4897,17 +3545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56770675ebc04927ded3e60633437841581c285dc6236109ea25fbf3beb7b59e"
 
 [[package]]
-name = "rstar"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
-dependencies = [
- "num-traits",
- "pdqselect",
- "threadpool",
-]
-
-[[package]]
 name = "rust-bert"
 version = "0.10.0"
 source = "git+https://github.com/mfelsche/rust-bert.git?rev=1140989#11409893d61afecc76145791d1b59bc4eab5170d"
@@ -4922,7 +3559,7 @@ dependencies = [
  "serde_json",
  "tch",
  "thiserror",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -4976,19 +3613,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
-dependencies = [
- "base64 0.12.3",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
@@ -4998,18 +3622,6 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls 0.19.1",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -5151,18 +3763,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aee4e0da52d801acfbc0cc219eb1eda7142112339726e427926a6f6ee65d3a"
-dependencies = [
- "syn 0.11.11",
- "synom",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5182,33 +3784,9 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
-dependencies = [
- "dtoa",
- "itoa",
- "serde",
- "url 1.7.2",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
-dependencies = [
- "dtoa",
- "itoa",
- "serde",
- "url 2.2.2",
 ]
 
 [[package]]
@@ -5233,43 +3811,6 @@ dependencies = [
  "indexmap",
  "serde",
  "yaml-rust",
-]
-
-[[package]]
-name = "serenity"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6275d443266aedf2be507a245ddc23db0c07b1b99774e16f3c879e96a78b067a"
-dependencies = [
- "async-trait",
- "async-tungstenite 0.11.0",
- "base64 0.13.0",
- "bitflags",
- "bytes 1.1.0",
- "chrono",
- "flate2",
- "futures 0.3.17",
- "percent-encoding 2.1.0",
- "reqwest 0.11.6",
- "serde",
- "serde_json",
- "tokio 1.12.0",
- "tracing",
- "typemap_rev",
- "url 2.2.2",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer",
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest",
- "opaque-debug",
 ]
 
 [[package]]
@@ -5335,24 +3876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signatory"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eaebd4be561a7d8148803baa108092f85090189c4b8c3ffb81602b15b5c1771"
-dependencies = [
- "getrandom 0.1.16",
- "signature",
- "subtle-encoding",
- "zeroize",
-]
-
-[[package]]
-name = "signature"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
-
-[[package]]
 name = "simd-json"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5386,9 +3909,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "929b468389809e93768ab7962f21aad7911774d472aca6211e332f74824c4635"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
+ "quote",
  "simd-json",
- "syn 1.0.81",
+ "syn",
 ]
 
 [[package]]
@@ -5404,17 +3927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "simple_asn1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
-dependencies = [
- "chrono",
- "num-bigint 0.2.6",
- "num-traits",
 ]
 
 [[package]]
@@ -5442,13 +3954,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
 dependencies = [
  "crc32fast",
- "crossbeam-epoch 0.9.5",
- "crossbeam-utils 0.8.5",
+ "crossbeam-epoch",
+ "crossbeam-utils",
  "fs2",
  "fxhash",
  "libc",
  "log",
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -5464,36 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
-
-[[package]]
-name = "smol"
-version = "1.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf3b5351f3e783c1d79ab5fc604eeed8b8ae9abd36b166e8b87a089efd85e4"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-net",
- "async-process",
- "blocking",
- "futures-lite",
- "once_cell",
-]
 
 [[package]]
 name = "snap"
@@ -5553,19 +4038,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
 dependencies = [
- "lock_api 0.4.5",
-]
-
-[[package]]
-name = "sse-codec"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a59f811350c44b4a037aabeb72dc6a9591fc22aa95a036db9a96297c58085a"
-dependencies = [
- "bytes 0.5.6",
- "futures-io",
- "futures_codec",
- "memchr",
+ "lock_api",
 ]
 
 [[package]]
@@ -5610,10 +4083,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
+ "quote",
  "serde",
  "serde_derive",
- "syn 1.0.81",
+ "syn",
 ]
 
 [[package]]
@@ -5624,12 +4097,12 @@ checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
  "proc-macro2",
- "quote 1.0.10",
+ "quote",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.81",
+ "syn",
 ]
 
 [[package]]
@@ -5639,15 +4112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
-name = "string"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
-dependencies = [
- "bytes 0.4.12",
-]
-
-[[package]]
 name = "string_cache"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5655,19 +4119,9 @@ checksum = "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "parking_lot 0.11.2",
- "phf_shared 0.8.0",
+ "parking_lot",
+ "phf_shared",
  "precomputed-hash",
-]
-
-[[package]]
-name = "stringprep"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -5698,15 +4152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
-name = "subtle-encoding"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
 name = "surf"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5730,33 +4175,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "surf-sse"
-version = "1.0.0"
-source = "git+https://github.com/dak-x/surf-sse?tag=2.0#c7a7d5d989c3cbde1922f52cee4824f771caf9b0"
-dependencies = [
- "futures-core",
- "futures-timer",
- "log",
- "sse-codec",
- "surf",
-]
-
-[[package]]
 name = "sval"
 version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
-
-[[package]]
-name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
 
 [[package]]
 name = "syn"
@@ -5765,17 +4187,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "unicode-xid 0.2.2",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -5785,9 +4198,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
- "unicode-xid 0.2.2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -5825,18 +4238,6 @@ dependencies = [
  "thiserror",
  "torch-sys",
  "zip",
-]
-
-[[package]]
-name = "tcp-stream"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12669e6606f91cd87e01c3d3411236ea10cf570e9f262d1aaefbe8b7502ca3fb"
-dependencies = [
- "cfg-if 1.0.0",
- "mio 0.7.14",
- "native-tls",
- "pem",
 ]
 
 [[package]]
@@ -5891,8 +4292,8 @@ checksum = "3b114ece25254e97bf48dd4bfc2a12bad0647adacfe4cae1247a9ca6ad302cec"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -5930,8 +4331,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5952,15 +4353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]
@@ -6029,9 +4421,9 @@ checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.10",
+ "quote",
  "standback",
- "syn 1.0.81",
+ "syn",
 ]
 
 [[package]]
@@ -6070,30 +4462,6 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "mio 0.6.23",
- "num_cpus",
- "tokio-codec",
- "tokio-current-thread",
- "tokio-executor",
- "tokio-fs",
- "tokio-io",
- "tokio-reactor",
- "tokio-sync",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
- "tokio-udp",
- "tokio-uds",
-]
-
-[[package]]
-name = "tokio"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
@@ -6116,7 +4484,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46409491c9375a693ce7032101970a54f8a2010efb77e13f70788f0d84489e39"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num_cpus",
  "pin-project-lite 0.2.7",
  "slab",
@@ -6128,7 +4496,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "bytes 1.1.0",
  "libc",
  "memchr",
@@ -6137,70 +4505,6 @@ dependencies = [
  "pin-project-lite 0.2.7",
  "tokio-macros",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio-buf"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
-dependencies = [
- "bytes 0.4.12",
- "either",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "tokio-io",
-]
-
-[[package]]
-name = "tokio-current-thread"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
-dependencies = [
- "futures 0.1.31",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-fs"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
-dependencies = [
- "futures 0.1.31",
- "tokio-io",
- "tokio-threadpool",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log",
 ]
 
 [[package]]
@@ -6220,60 +4524,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio 1.12.0",
-]
-
-[[package]]
-name = "tokio-postgres"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c07a6ceeeb8515d53998ac4487788a21884e79d5651490bc31a7289f20a7d7"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes 1.1.0",
- "fallible-iterator",
- "futures 0.3.17",
- "log",
- "parking_lot 0.11.2",
- "percent-encoding 2.1.0",
- "phf",
- "pin-project-lite 0.2.7",
- "postgres-protocol",
- "postgres-types",
- "socket2 0.4.2",
- "tokio 1.12.0",
- "tokio-util 0.6.8",
-]
-
-[[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
- "lazy_static",
- "log",
- "mio 0.6.23",
- "num_cpus",
- "parking_lot 0.9.0",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6282,7 +4534,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls 0.19.1",
+ "rustls",
  "tokio 1.12.0",
  "webpki",
 ]
@@ -6299,59 +4551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-sync"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
-dependencies = [
- "fnv",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "mio 0.6.23",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-threadpool"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
-dependencies = [
- "crossbeam-deque 0.7.4",
- "crossbeam-queue 0.2.3",
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
- "lazy_static",
- "log",
- "num_cpus",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-timer"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
 name = "tokio-tls"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6359,39 +4558,6 @@ checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
  "tokio 0.2.25",
-]
-
-[[package]]
-name = "tokio-udp"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log",
- "mio 0.6.23",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-uds"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "libc",
- "log",
- "mio 0.6.23",
- "mio-uds",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
 ]
 
 [[package]]
@@ -6423,15 +4589,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "tonic"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6444,12 +4601,12 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.3.7",
- "http 0.2.5",
+ "http",
  "http-body 0.4.4",
  "hyper 0.14.14",
  "hyper-timeout",
- "percent-encoding 2.1.0",
- "pin-project 1.0.8",
+ "percent-encoding",
+ "pin-project",
  "prost",
  "prost-derive",
  "tokio 1.12.0",
@@ -6471,8 +4628,8 @@ checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
 dependencies = [
  "proc-macro2",
  "prost-build",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6498,7 +4655,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 1.0.8",
+ "pin-project",
  "pin-project-lite 0.2.7",
  "rand 0.8.4",
  "slab",
@@ -6542,8 +4699,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6561,7 +4718,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.8",
+ "pin-project",
  "tracing",
 ]
 
@@ -6600,9 +4757,9 @@ dependencies = [
  "difference",
  "dirs-next",
  "env_logger 0.9.0",
- "error-chain 0.12.4",
+ "error-chain",
  "float-cmp",
- "futures 0.3.17",
+ "futures",
  "globwalk",
  "halfbrown",
  "http-types",
@@ -6631,7 +4788,7 @@ dependencies = [
  "tremor-pipeline",
  "tremor-runtime",
  "tremor-script",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -6684,7 +4841,7 @@ dependencies = [
  "beef",
  "byteorder",
  "criterion",
- "error-chain 0.12.4",
+ "error-chain",
  "halfbrown",
  "indexmap",
  "lazy_static",
@@ -6703,7 +4860,7 @@ dependencies = [
  "tremor-common",
  "tremor-script",
  "tremor-value",
- "url 2.2.2",
+ "url",
  "value-trait",
  "window",
  "xz2",
@@ -6713,41 +4870,30 @@ dependencies = [
 name = "tremor-runtime"
 version = "0.11.4"
 dependencies = [
+ "abi_stable",
  "anyhow",
  "async-broadcast",
  "async-compat",
  "async-compression",
- "async-nats",
  "async-std",
- "async-std-resolver",
- "async-tls",
  "async-trait",
- "async-tungstenite 0.14.0",
  "base64 0.13.0",
  "beef",
  "bimap",
  "byteorder",
  "bytes 1.1.0",
  "chrono",
- "cron",
  "either",
- "elastic",
  "env_logger 0.9.0",
- "error-chain 0.12.4",
- "futures 0.3.17",
+ "error-chain",
+ "futures",
  "glob",
- "googapis",
- "gouth",
- "grok",
  "halfbrown",
  "hashbrown 0.11.2",
- "hdrhistogram",
  "hex",
  "hostname",
- "http 0.2.5",
  "http-types",
  "indexmap",
- "lapin",
  "lazy_static",
  "libflate",
  "log",
@@ -6755,38 +4901,22 @@ dependencies = [
  "lz4",
  "mapr",
  "matches",
- "openssl",
  "pin-project-lite 0.2.7",
  "port_scanner",
- "postgres",
- "postgres-protocol",
  "pretty_assertions",
  "proptest",
  "rand 0.8.4",
- "rdkafka",
- "rdkafka-sys",
  "regex",
- "rental",
- "reqwest 0.11.6",
  "rmp-serde",
- "rustls 0.19.1",
- "rustls-native-certs",
  "serde",
  "serde_derive",
  "serde_yaml",
- "serenity",
  "simd-json",
  "simd-json-derive",
- "sled",
- "smol",
  "snap",
  "surf",
- "surf-sse",
  "syslog_loose",
- "tempfile",
  "test-case",
- "tide",
- "tokio-postgres",
  "tonic",
  "tremor-common",
  "tremor-influx",
@@ -6794,7 +4924,7 @@ dependencies = [
  "tremor-pipeline",
  "tremor-script",
  "tremor-value",
- "url 2.2.2",
+ "url",
  "value-trait",
  "xz2",
  "zstd",
@@ -6815,7 +4945,7 @@ dependencies = [
  "dissect",
  "distance",
  "downcast-rs",
- "error-chain 0.12.4",
+ "error-chain",
  "float-cmp",
  "fxhash",
  "glob",
@@ -6828,7 +4958,7 @@ dependencies = [
  "lalrpop-util",
  "lazy_static",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pretty_assertions",
  "proptest",
  "rand 0.8.4",
@@ -6845,8 +4975,8 @@ dependencies = [
  "tremor-influx",
  "tremor-kv",
  "tremor-value",
- "unicode-xid 0.2.2",
- "url 2.2.2",
+ "unicode-xid",
+ "url",
  "value-trait",
  "xz2",
 ]
@@ -6868,62 +4998,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0d7f5db438199a6e2609debe3f69f808d074e0a2888ee0bccb45fe234d03f4"
-dependencies = [
- "async-trait",
- "cfg-if 1.0.0",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "log",
- "rand 0.8.4",
- "smallvec 1.7.0",
- "thiserror",
- "tinyvec",
- "url 2.2.2",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad17b608a64bd0735e67bde16b0636f8aa8591f831a25d18443ed00a699770"
-dependencies = [
- "cfg-if 1.0.0",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "log",
- "lru-cache",
- "parking_lot 0.11.2",
- "resolv-conf",
- "smallvec 1.7.0",
- "thiserror",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "try_from"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
-dependencies = [
- "cfg-if 0.1.10",
-]
 
 [[package]]
 name = "tstr"
@@ -6941,45 +5019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
 
 [[package]]
-name = "tungstenite"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
-dependencies = [
- "base64 0.12.3",
- "byteorder",
- "bytes 0.5.6",
- "http 0.2.5",
- "httparse",
- "input_buffer 0.3.1",
- "log",
- "rand 0.7.3",
- "sha-1",
- "url 2.2.2",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
-dependencies = [
- "base64 0.13.0",
- "byteorder",
- "bytes 1.1.0",
- "http 0.2.5",
- "httparse",
- "input_buffer 0.4.0",
- "log",
- "rand 0.8.4",
- "sha-1",
- "thiserror",
- "url 2.2.2",
- "utf-8",
-]
-
-[[package]]
 name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6993,12 +5032,6 @@ checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
 dependencies = [
  "unsafe-any",
 ]
-
-[[package]]
-name = "typemap_rev"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5b74f0a24b5454580a79abb6994393b09adf0ab8070f15827cb666255de155"
 
 [[package]]
 name = "typenum"
@@ -7036,7 +5069,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
- "smallvec 1.7.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -7050,12 +5083,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
@@ -7090,58 +5117,22 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "uuid"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
-dependencies = [
- "cfg-if 0.1.10",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "uuid"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-dependencies = [
- "rand 0.6.5",
-]
 
 [[package]]
 name = "uuid"
@@ -7212,7 +5203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
+ "quote",
 ]
 
 [[package]]
@@ -7239,17 +5230,6 @@ dependencies = [
  "same-file",
  "winapi 0.3.9",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
-dependencies = [
- "futures 0.1.31",
- "log",
- "try-lock",
 ]
 
 [[package]]
@@ -7296,8 +5276,8 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -7319,7 +5299,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
- "quote 1.0.10",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -7330,8 +5310,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7363,33 +5343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
-]
-
-[[package]]
 name = "wepoll-ffi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7417,18 +5370,6 @@ dependencies = [
  "lazy_static",
  "libc",
 ]
-
-[[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
-
-[[package]]
-name = "wildmatch"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f44b95f62d34113cf558c93511ac93027e03e9c29a60dd0fd70e6e025c7270a"
 
 [[package]]
 name = "winapi"
@@ -7483,15 +5424,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
@@ -7534,27 +5466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
-dependencies = [
- "proc-macro2",
- "quote 1.0.10",
- "syn 1.0.81",
- "synstructure",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ members = [
   "tremor-value",
 ]
 
+exclude = [
+  "plugins"
+]
+
 [profile.release]
 debug = true
 lto = "thin"
@@ -83,83 +87,11 @@ tremor-pipeline = { path = "tremor-pipeline" }
 tremor-script = { path = "tremor-script" }
 tremor-value = { path = "tremor-value" }
 url = "2.2"
-value-trait = "0.2"
+value-trait = { version = "0.2.9", features = ["c-abi"] }
 zstd = "0.9"
 
 mapr = "0.8"
-
-# blaster / blackhole
-hdrhistogram = "7"
 xz2 = "0.1"
-
-# postgres
-postgres = { version = "0.19", features = [
-  "with-serde_json-1",
-  "with-chrono-0_4",
-] }
-postgres-protocol = "0.6"
-tempfile = { version = "3.2" }
-tokio-postgres = "0.7"
-
-# amqp
-lapin = "1.8"
-
-# elasticsearch
-elastic = "0.21.0-pre.5"
-
-# ws
-async-tungstenite = { version = "0.14.0", features = ["async-std-runtime"] }
-
-# for tcp
-async-tls = "0.11"
-rustls = "0.19"
-rustls-native-certs = "0.5"
-
-# dns
-async-std-resolver = "0.20"
-
-# kafka. cmake is the encouraged way to build this and also the one that works on windows/with musl.
-rdkafka = { version = "0.26", features = [
-  "cmake-build",
-  "libz-static",
-], default-features = false }
-rdkafka-sys = { version = "4.0.0", features = [
-  "cmake-build",
-  "libz-static",
-] } # tracking the version rdkafka depends on
-rental = "0.5"
-smol = "1.2.5"
-
-# crononome
-cron = "0.9.0"
-
-# logstash grok patterns
-grok = "1"
-
-# not used directly in tremor codebase, but present here so that we can turn
-# on features for these (see static-ssl feature here)
-openssl = { version = "0.10", features = ["vendored"] }
-
-#rest onramp
-tide = "0.16"
-
-# sse-onramp
-surf-sse = { git = "https://github.com/dak-x/surf-sse", tag = "2.0" }
-
-# nats
-async-nats = "0.10.1"
-
-# discord
-serenity = { version = "0.10", default-features = false, features = [
-  "client",
-  "gateway",
-  "rustls_backend",
-  "model",
-  "cache",
-] }
-
-# kv
-sled = "0.34"
 
 # opentelemetry
 port_scanner = "0.1.5"
@@ -169,13 +101,8 @@ tonic = { version = "0.5.2", default-features = false, features = [
 ] }
 tremor-otelapis = { version = "0.2.2" }
 
-# gcp
-googapis = { version = "0.5", default-features = false, features = [
-  "google-pubsub-v1",
-] }
-gouth = { version = "0.2" }
-http = "0.2.4"
-reqwest = "0.11.4"
+# plugin system
+abi_stable = "0.10.3"
 
 [dev-dependencies]
 matches = "0.1"

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -13,4 +13,3 @@
 // limitations under the License.
 
 pub(crate) mod mmap;
-pub(crate) mod postgres;

--- a/src/connectors.rs
+++ b/src/connectors.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// quality of service utilities
-pub(crate) mod qos;
-
 /// prelude with commonly needed stuff imported
 pub(crate) mod prelude;
 /// Sink part of a connector
@@ -28,41 +25,20 @@ pub(crate) mod reconnect;
 /// home for connector specific function
 pub(crate) mod functions;
 
-/// google cloud pubsub/storage/auth
-pub(crate) mod gcp;
+/// Home of the famous metrics collector
+pub(crate) mod metrics;
+
+/// Exit Connector
+// pub(crate) mod exit;
+/// quiescence stuff
+pub(crate) mod quiescence;
+
 /// opentelemetry
 pub(crate) mod otel;
 /// protobuf helpers
 pub(crate) mod pb;
 
-/// file connector implementation
-pub mod file;
-
-/// tcp server and client connector impls
-pub(crate) mod tcp;
-
-/// udp server connector impl
-pub(crate) mod udp_server;
-
-/// udp server connector impl
-pub(crate) mod udp_client;
-
-/// std streams connector (stdout, stderr, stdin)
-pub(crate) mod std_streams;
-
-/// Home of the famous metrics collector
-pub(crate) mod metrics;
-
-/// Metronome
-pub(crate) mod metronome;
-
-/// Exit Connector
-pub(crate) mod exit;
-/// quiescence stuff
-pub(crate) mod quiescence;
-
-/// collection of TLS utilities and configs
-pub(crate) mod tls;
+pub mod plugins;
 
 use std::fmt::Display;
 
@@ -73,7 +49,7 @@ use crate::config::Connector as ConnectorConfig;
 use crate::connectors::metrics::{MetricsSinkReporter, SourceReporter};
 use crate::connectors::sink::{SinkAddr, SinkContext, SinkMsg};
 use crate::connectors::source::{SourceAddr, SourceContext, SourceMsg};
-use crate::errors::{Error, ErrorKind, Result};
+use crate::errors::{Error, ErrorKind, RResult, Result};
 use crate::pipeline;
 use crate::system::World;
 use crate::url::ports::{ERR, IN, OUT};
@@ -88,6 +64,20 @@ use value_trait::{Builder, Mutable};
 use self::metrics::MetricsSender;
 use self::quiescence::QuiescenceBeacon;
 use self::reconnect::{Attempt, ReconnectRuntime};
+
+use abi_stable::{
+    StableAbi,
+    declare_root_module_statics,
+    library::RootModule,
+    package_version_strings,
+    sabi_types::VersionStrings,
+    std_types::{
+        RBox,
+        ROption::{self, RNone},
+        RResult::{RErr, ROk},
+        RStr, RString,
+    },
+};
 
 /// sender for connector manager messages
 pub type ManagerSender = Sender<ManagerMsg>;
@@ -405,7 +395,7 @@ impl Manager {
         &self,
         addr_tx: Sender<Result<Addr>>,
         url: TremorUrl,
-        mut connector: Box<dyn Connector>,
+        mut connector: Connector,
         config: ConnectorConfig,
         uid: u64,
     ) -> Result<()> {
@@ -421,7 +411,7 @@ impl Manager {
             config.metrics_interval_s,
         );
 
-        let default_codec = connector.default_codec();
+        let default_codec = connector.default_codec().into();
         let source_builder = source::builder(
             uid,
             &config,
@@ -640,7 +630,7 @@ impl Manager {
                     Msg::Reconnect => {
                         // reconnect if we are below max_retries, otherwise bail out and fail the connector
                         info!("[Connector::{}] Connecting...", &addr.url);
-                        let new = reconnect.attempt(connector.as_mut(), &ctx).await?;
+                        let new = reconnect.attempt(&mut connector, &ctx).await?;
                         match (&connectivity, &new) {
                             (Connectivity::Disconnected, Connectivity::Connected) => {
                                 info!("[Connector::{}] Connected.", &addr.url);
@@ -877,7 +867,8 @@ impl Drainage {
 }
 
 /// state of a connector
-#[derive(Debug, PartialEq, Serialize, Deserialize, Copy, Clone)]
+#[repr(C)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Copy, Clone, StableAbi)]
 #[serde(rename_all = "lowercase")]
 pub enum ConnectorState {
     /// connector has been initialized, but not yet started
@@ -908,7 +899,8 @@ impl Display for ConnectorState {
 }
 
 /// connector context
-#[derive(Clone)]
+#[repr(C)]
+#[derive(Clone, StableAbi)]
 pub struct ConnectorContext {
     /// unique identifier
     pub uid: u64,
@@ -919,7 +911,7 @@ pub struct ConnectorContext {
     /// The Quiescence Beacon
     pub quiescence_beacon: QuiescenceBeacon,
     /// Notifier
-    pub notifier: reconnect::ConnectionLostNotifier,
+    pub notifier: reconnect::ConnectionLostNotifier, // TODO: StableAbi
 }
 
 impl ConnectorContext {
@@ -945,42 +937,31 @@ pub enum Connectivity {
     Disconnected,
 }
 
-/// A Connector connects the tremor runtime to the outside world.
-///
-/// It can be a source of events, as such it is polled for new data.
-/// It can also be a sink for events, as such events are sent to it from pipelines.
-/// A connector can act as sink and source or just as one of those.
-///
-/// A connector encapsulates the establishment and maintenance of connections to the outside world,
-/// such as tcp connections, file handles etc. etc.
-///
-/// It is a meta entity on top of the sink and source part.
-/// The connector has its own control plane and is an artefact in the tremor repository.
-/// It controls the sink and source parts which are connected to the rest of the runtime via links to pipelines.
-#[async_trait::async_trait]
-pub trait Connector: Send {
+// The low-level connector interface used for the plugins
+#[abi_stable::sabi_trait]
+pub trait RawConnector: Send {
     /// create a source part for this connector if applicable
     ///
     /// This function is called exactly once upon connector creation.
     /// If this connector does not act as a source, return `Ok(None)`.
-    async fn create_source(
+    fn create_source(
         &mut self,
         _source_context: SourceContext,
         _builder: source::SourceManagerBuilder,
-    ) -> Result<Option<source::SourceAddr>> {
-        Ok(None)
+    ) -> RResult<ROption<source::SourceAddr>> { // TODO derive StableAbi
+        ROk(RNone)
     }
 
     /// Create a sink part for this connector if applicable
     ///
     /// This function is called exactly once upon connector creation.
     /// If this connector does not act as a sink, return `Ok(None)`.
-    async fn create_sink(
+    fn create_sink(
         &mut self,
         _sink_context: SinkContext,
         _builder: sink::SinkManagerBuilder,
-    ) -> Result<Option<sink::SinkAddr>> {
-        Ok(None)
+    ) -> RResult<ROption<sink::SinkAddr>> { // TODO derive StableAbi
+        ROk(RNone)
     }
 
     /// Attempt to connect to the outside world.
@@ -997,30 +978,98 @@ pub trait Connector: Send {
     ///
     /// To know when to stop reading new data from the external connection, the `quiescence` beacon
     /// can be used. Call `.reading()` and `.writing()` to see if you should continue doing so, if not, just stop and rest.
-    async fn connect(&mut self, ctx: &ConnectorContext, attempt: &Attempt) -> Result<bool>;
+    fn connect(&mut self, ctx: &ConnectorContext, attempt: &Attempt) -> RResult<bool>;
 
     /// called once when the connector is started
     /// `connect` will be called after this for the first time, leave connection attempts in `connect`.
-    async fn on_start(&mut self, _ctx: &ConnectorContext) -> Result<ConnectorState> {
-        Ok(ConnectorState::Running)
+    fn on_start(&mut self, _ctx: &ConnectorContext) -> RResult<ConnectorState> {
+        ROk(ConnectorState::Running)
     }
 
     /// called when the connector pauses
-    async fn on_pause(&mut self, _ctx: &ConnectorContext) {}
+    fn on_pause(&mut self, _ctx: &ConnectorContext) {}
     /// called when the connector resumes
-    async fn on_resume(&mut self, _ctx: &ConnectorContext) {}
+    fn on_resume(&mut self, _ctx: &ConnectorContext) {}
 
     /// Drain
     ///
     /// Ensure no new events arrive at the source part of this connector when this function returns
     /// So we can safely send the `Drain` signal.
-    async fn on_drain(&mut self, _ctx: &ConnectorContext) {}
+    fn on_drain(&mut self, _ctx: &ConnectorContext) {}
 
     /// called when the connector is stopped
-    async fn on_stop(&mut self, _ctx: &ConnectorContext) {}
+    fn on_stop(&mut self, _ctx: &ConnectorContext) {}
 
     /// returns the default codec for this connector
-    fn default_codec(&self) -> &str;
+    fn default_codec<'a>(&'a self) -> RStr<'a>;
+}
+
+// The higher level connector interface, which wraps the raw connector from the
+// plugin.
+pub struct Connector(pub RawConnector_TO<'static, RBox<()>>);
+impl Connector {
+    #[inline]
+    pub async fn create_source(
+        &mut self,
+        source_context: SourceContext,
+        builder: source::SourceManagerBuilder,
+    ) -> Result<Option<source::SourceAddr>> {
+        match self.0.create_source(source_context, builder) {
+            ROk(source) => Ok(source.into()),
+            RErr(err) => Err(err),
+        }
+    }
+
+    #[inline]
+    pub async fn create_sink(
+        &mut self,
+        sink_context: SinkContext,
+        builder: sink::SinkManagerBuilder,
+    ) -> Result<Option<sink::SinkAddr>> {
+        match self.0.create_sink(sink_context, builder) {
+            ROk(sink) => Ok(sink.into()),
+            RErr(err) => Err(err),
+        }
+    }
+
+    #[inline]
+    pub async fn connect(
+        &mut self,
+        ctx: &ConnectorContext,
+        notifier: &Attempt,
+    ) -> Result<bool> {
+        self.0.connect(ctx, notifier).into()
+    }
+
+    #[inline]
+    pub async fn on_start(&mut self, ctx: &ConnectorContext) -> Result<ConnectorState> {
+        self.0.on_start(ctx).into()
+    }
+
+    #[inline]
+    pub async fn on_pause(&mut self, ctx: &ConnectorContext) {
+        self.0.on_pause(ctx)
+    }
+
+    #[inline]
+    pub async fn on_resume(&mut self, ctx: &ConnectorContext) {
+        self.0.on_resume(ctx)
+    }
+
+    #[inline]
+    pub async fn on_drain(&mut self, ctx: &ConnectorContext) {
+        self.0.on_drain(ctx)
+    }
+
+    #[inline]
+    pub async fn on_stop(&mut self, ctx: &ConnectorContext) {
+        self.0.on_stop(ctx)
+    }
+
+    #[inline]
+    pub fn default_codec(&self) -> &str {
+        self.0.default_codec().into()
+    }
 }
 
 /// something that is able to create a connector instance
@@ -1030,11 +1079,7 @@ pub trait ConnectorBuilder: Sync + Send {
     ///
     /// # Errors
     ///  * If the config is invalid for the connector
-    async fn from_config(
-        &self,
-        id: &TremorUrl,
-        config: &Option<OpConfig>,
-    ) -> Result<Box<dyn Connector>>;
+    async fn from_config(&self, id: &TremorUrl, config: &Option<OpConfig>) -> Result<Connector>;
 }
 
 /// registering builtin connector types
@@ -1043,29 +1088,6 @@ pub trait ConnectorBuilder: Sync + Send {
 ///  * If a builtin connector couldn't be registered
 #[cfg(not(tarpaulin_include))]
 pub async fn register_builtin_connector_types(world: &World) -> Result<()> {
-    world
-        .register_builtin_connector_type("exit", Box::new(exit::Builder::new(world)))
-        .await?;
-    world
-        .register_builtin_connector_type("file", Box::new(file::Builder::new(world)))
-        .await?;
-    world
-        .register_builtin_connector_type("metrics", Box::new(metrics::Builder::default()))
-        .await?;
-    world
-        .register_builtin_connector_type("std_stream", Box::new(std_streams::Builder::default()))
-        .await?;
-    world
-        .register_builtin_connector_type("tcp_client", Box::new(tcp::client::Builder::default()))
-        .await?;
-    world
-        .register_builtin_connector_type("tcp_server", Box::new(tcp::server::Builder::default()))
-        .await?;
-    world
-        .register_builtin_connector_type("udp_client", Box::new(udp_client::Builder::default()))
-        .await?;
-    world
-        .register_builtin_connector_type("udp_server", Box::new(udp_server::Builder::default()))
-        .await?;
+    // TODO: load dynamically
     Ok(())
 }

--- a/src/connectors/metrics.rs
+++ b/src/connectors/metrics.rs
@@ -18,6 +18,7 @@ use crate::connectors::prelude::*;
 use crate::errors::{ErrorKind, Result};
 use crate::url::ports::{ERR, IN, OUT};
 use crate::url::TremorUrl;
+use abi_stable::{std_types::ROption, StableAbi};
 use async_broadcast::{broadcast, Receiver, Sender, TryRecvError, TrySendError};
 use beef::Cow;
 use halfbrown::HashMap;
@@ -25,7 +26,6 @@ use tremor_pipeline::{CbAction, Event, EventOriginUri, DEFAULT_STREAM_ID};
 use tremor_script::utils::hostname;
 use tremor_script::EventPayload;
 use tremor_value::prelude::*;
-use abi_stable::{StableAbi, std_types::ROption};
 
 const MEASUREMENT: Cow<'static, str> = Cow::const_str("measurement");
 const TAGS: Cow<'static, str> = Cow::const_str("tags");

--- a/src/connectors/metrics.rs
+++ b/src/connectors/metrics.rs
@@ -25,6 +25,7 @@ use tremor_pipeline::{CbAction, Event, EventOriginUri, DEFAULT_STREAM_ID};
 use tremor_script::utils::hostname;
 use tremor_script::EventPayload;
 use tremor_value::prelude::*;
+use abi_stable::{StableAbi, std_types::ROption};
 
 const MEASUREMENT: Cow<'static, str> = Cow::const_str("measurement");
 const TAGS: Cow<'static, str> = Cow::const_str("tags");
@@ -61,7 +62,7 @@ impl MetricsChannel {
 }
 #[derive(Debug, Clone)]
 pub struct Msg {
-    payload: EventPayload,
+    payload: EventPayload, // TODO
     origin_uri: Option<EventOriginUri>,
 }
 
@@ -80,7 +81,7 @@ pub struct SourceReporter {
     metrics_out: u64,
     metrics_err: u64,
     tx: Sender<Msg>,
-    flush_interval_ns: Option<u64>,
+    flush_interval_ns: ROption<u64>,
     last_flush_ns: u64,
 }
 
@@ -200,79 +201,6 @@ fn make_metrics_payload(
     let value = tremor_pipeline::influx_value(Cow::from("ramp_events"), tags, count, timestamp);
     // full metrics payload
     (value, Value::object()).into()
-}
-
-/// This is a system connector to collect and forward metrics.
-/// System metrics are fed to this connector and can be received by binding this connector's `out` port to a pipeline to handle metrics events.
-/// It can also be used to send custom metrics and have them handled the same way as system metrics.
-/// Custom metrics need to be sent as events to the `in` port of this connector.
-///
-/// TODO: describe metrics event format and write stdlib function to help with that
-///
-/// There should be only one instance around all the time, identified by `tremor://localhost/connector/system::metrics/system`
-///
-pub(crate) struct MetricsConnector {
-    tx: Sender<Msg>,
-    rx: Receiver<Msg>,
-}
-
-impl MetricsConnector {
-    pub(crate) fn new() -> Self {
-        Self {
-            tx: METRICS_CHANNEL.tx(),
-            rx: METRICS_CHANNEL.rx(),
-        }
-    }
-}
-
-/// builder for the metrics connector
-
-#[derive(Debug, Default)]
-pub(crate) struct Builder {}
-#[async_trait::async_trait]
-impl ConnectorBuilder for Builder {
-    async fn from_config(
-        &self,
-        _id: &TremorUrl,
-        _config: &Option<serde_yaml::Value>,
-    ) -> Result<Box<dyn Connector>> {
-        Ok(Box::new(MetricsConnector::new()))
-    }
-}
-
-#[async_trait::async_trait()]
-impl Connector for MetricsConnector {
-    async fn connect(&mut self, _ctx: &ConnectorContext, _attempt: &Attempt) -> Result<bool> {
-        Ok(!self.tx.is_closed())
-    }
-
-    async fn create_source(
-        &mut self,
-        source_context: SourceContext,
-        builder: SourceManagerBuilder,
-    ) -> Result<Option<SourceAddr>> {
-        let source = MetricsSource::new(self.rx.clone());
-        let addr = builder.spawn(source, source_context)?;
-        Ok(Some(addr))
-    }
-
-    async fn create_sink(
-        &mut self,
-        sink_context: SinkContext,
-        builder: SinkManagerBuilder,
-    ) -> Result<Option<SinkAddr>> {
-        let sink = MetricsSink::new(self.tx.clone());
-        let addr = builder.spawn(sink, sink_context)?;
-        Ok(Some(addr))
-    }
-
-    async fn on_start(&mut self, _ctx: &ConnectorContext) -> Result<ConnectorState> {
-        Ok(ConnectorState::Running)
-    }
-
-    fn default_codec(&self) -> &str {
-        "json"
-    }
 }
 
 pub(crate) struct MetricsSource {

--- a/src/connectors/plugins.rs
+++ b/src/connectors/plugins.rs
@@ -1,0 +1,30 @@
+//! Defines the interface between the plugins and the runtime.
+
+use crate::connectors::RawConnector_TO;
+
+use abi_stable::{
+    declare_root_module_statics, library::RootModule, package_version_strings,
+    sabi_types::VersionStrings, std_types::RBox, StableAbi,
+};
+
+#[repr(C)]
+#[derive(StableAbi)]
+#[sabi(kind(Prefix))]
+pub struct ConnectorMod {
+    pub new: extern "C" fn() -> RawConnector_TO<'static, RBox<()>>,
+}
+
+// Marking `MinMod` as the main module in this plugin. Note that `MinMod_Ref` is
+// a pointer to the prefix of `MinMod`.
+impl RootModule for ConnectorMod_Ref {
+    // The name of the dynamic library
+    const BASE_NAME: &'static str = "connector";
+    // The name of the library for logging and similars
+    const NAME: &'static str = "connector";
+    // The version of this plugin's crate
+    const VERSION_STRINGS: VersionStrings = package_version_strings!();
+
+    // Implements the `RootModule::root_module_statics` function, which is the
+    // only required implementation for the `RootModule` trait.
+    declare_root_module_statics! {ConnectorMod_Ref}
+}

--- a/src/connectors/quiescence.rs
+++ b/src/connectors/quiescence.rs
@@ -14,20 +14,22 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use abi_stable::{StableAbi, std_types::RArc};
 
 /// use this beacon to check if tasks reading or writing from external connections should stop
-#[derive(Clone, Debug)]
+#[repr(C)]
+#[derive(Clone, Debug, StableAbi)]
 #[allow(clippy::module_name_repetitions)]
 pub struct QuiescenceBeacon {
-    read: Arc<AtomicBool>,
-    write: Arc<AtomicBool>,
+    read: RArc<AtomicBool>,
+    write: RArc<AtomicBool>,
 }
 
 impl Default for QuiescenceBeacon {
     fn default() -> Self {
         Self {
-            read: Arc::new(AtomicBool::new(true)),
-            write: Arc::new(AtomicBool::new(true)),
+            read: RArc::new(AtomicBool::new(true)),
+            write: RArc::new(AtomicBool::new(true)),
         }
     }
 }

--- a/src/connectors/quiescence.rs
+++ b/src/connectors/quiescence.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use abi_stable::{std_types::RArc, StableAbi};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use abi_stable::{StableAbi, std_types::RArc};
 
 /// use this beacon to check if tasks reading or writing from external connections should stop
 #[repr(C)]

--- a/src/connectors/reconnect.rs
+++ b/src/connectors/reconnect.rs
@@ -22,6 +22,8 @@ use async_std::task;
 use std::fmt::Display;
 use std::time::Duration;
 
+use abi_stable::StableAbi;
+
 #[derive(Debug, PartialEq, Clone)]
 enum ShouldRetry {
     Yes,
@@ -75,7 +77,8 @@ impl ReconnectStrategy for SimpleBackoff {
 }
 
 /// describing the number of previous connection attempts
-#[derive(Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+#[derive(Debug, Default, PartialEq, Eq, StableAbi)]
 pub struct Attempt {
     overall: u64,
     success: u64,
@@ -191,7 +194,7 @@ impl ReconnectRuntime {
     /// asynchronously and send a `connector::Msg::Reconnect` to the connector identified by `addr`.
     pub(crate) async fn attempt(
         &mut self,
-        connector: &mut dyn Connector,
+        connector: &mut Connector,
         ctx: &ConnectorContext,
     ) -> Result<Connectivity> {
         match connector.connect(ctx, &self.attempt).await {

--- a/src/connectors/reconnect.rs
+++ b/src/connectors/reconnect.rs
@@ -143,6 +143,7 @@ pub(crate) struct ReconnectRuntime {
 /// can use to asynchronously notify the runtime whenever their connection is lost
 ///
 /// This will change the connector state properly and trigger a new reconnect attempt (according to the configured logic)
+// TODO: StableAbi. This can be achieved by making it an opaque type.
 #[derive(Clone)]
 pub struct ConnectionLostNotifier(Sender<Msg>);
 

--- a/src/connectors/sink.rs
+++ b/src/connectors/sink.rs
@@ -43,6 +43,8 @@ use tremor_common::time::nanotime;
 use tremor_pipeline::{CbAction, Event, EventId, OpMeta, SignalKind, DEFAULT_STREAM_ID};
 use tremor_script::EventPayload;
 
+use abi_stable::StableAbi;
+
 use tremor_value::Value;
 
 use super::metrics::MetricsSinkReporter;
@@ -172,6 +174,8 @@ pub trait StreamWriter: Send + Sync {
     }
 }
 /// context for the connector sink
+#[repr(C)]
+#[derive(StableAbi)]
 pub struct SinkContext {
     /// the connector unique identifier
     pub uid: u64,
@@ -238,6 +242,8 @@ pub struct SinkAddr {
     pub addr: Sender<SinkMsg>,
 }
 
+#[repr(C)]
+#[derive(StableAbi)]
 pub struct SinkManagerBuilder {
     qsize: usize,
     serializer: EventSerializer,

--- a/src/connectors/source.rs
+++ b/src/connectors/source.rs
@@ -26,7 +26,7 @@ use tremor_script::{EventPayload, ValueAndMeta};
 use crate::codec::{self, Codec};
 use crate::config::{Codec as CodecConfig, Connector as ConnectorConfig};
 use crate::connectors::Msg;
-use crate::errors::{Error, Result};
+use crate::errors::{Error, Result, RResult};
 use crate::pipeline;
 use crate::preprocessor::{make_preprocessors, preprocess, Preprocessors};
 use crate::url::ports::{ERR, OUT};
@@ -38,6 +38,7 @@ use tremor_pipeline::{
 };
 use tremor_value::{literal, Value};
 use value_trait::Builder;
+use abi_stable::{StableAbi, std_types::{RString, RVec, ROption, Tuple2}};
 
 use super::metrics::SourceReporter;
 use super::quiescence::QuiescenceBeacon;
@@ -80,16 +81,17 @@ pub enum SourceMsg {
 }
 
 /// reply from `Source::on_event`
-#[derive(Debug)]
+#[repr(C)]
+#[derive(Debug, StableAbi)]
 pub enum SourceReply {
     /// A normal data event with a `Vec<u8>` for data
     Data {
         /// origin uri
         origin_uri: EventOriginUri,
         /// the data
-        data: Vec<u8>,
+        data: RVec<u8>,
         /// metadata associated with this data
-        meta: Option<Value<'static>>,
+        meta: ROption<Value<'static>>,
         /// stream id of the data
         stream: u64,
     },
@@ -103,7 +105,7 @@ pub enum SourceReply {
     // for when the source knows where boundaries are, maybe because it receives chunks already
     BatchData {
         origin_uri: EventOriginUri,
-        batch_data: Vec<(Vec<u8>, Option<Value<'static>>)>,
+        batch_data: RVec<Tuple2<RVec<u8>, ROption<Value<'static>>>>,
         stream: u64,
     },
     /// A stream is opened
@@ -116,6 +118,75 @@ pub enum SourceReply {
 
 // sender for source reply
 pub type SourceReplySender = Sender<SourceReply>;
+
+/// source part of a connector
+#[abi_stable::sabi_trait]
+pub trait RawSource: Send {
+    /// Pulls an event from the source if one exists
+    /// `idgen` is passed in so the source can inspect what event id it would get if it was producing 1 event from the pulled data
+    fn pull_data(&mut self, pull_id: u64, ctx: &SourceContext) -> RResult<SourceReply>;
+    /// This callback is called when the data provided from
+    /// pull_event did not create any events, this is needed for
+    /// linked sources that require a 1:1 mapping between requests
+    /// and responses, we're looking at you REST
+    fn on_no_events(
+        &mut self,
+        _pull_id: u64,
+        _stream: u64,
+        _ctx: &SourceContext,
+    ) -> RResult<()> {
+        Ok(())
+    }
+
+    /// Pulls custom metrics from the source
+    fn metrics(&mut self, _timestamp: u64) -> RVec<EventPayload> {
+        vec![]
+    }
+
+    ///////////////////////////
+    /// lifecycle callbacks ///
+    ///////////////////////////
+
+    /// called when the source is started. This happens only once in the whole source lifecycle, before any other callbacks
+    fn on_start(&mut self, _ctx: &mut SourceContext) {}
+    /// called when the source is explicitly paused as result of a user/operator interaction
+    /// in contrast to `on_cb_close` which happens automatically depending on downstream pipeline or sink connector logic.
+    fn on_pause(&mut self, _ctx: &mut SourceContext) {}
+    /// called when the source is explicitly resumed from being paused
+    fn on_resume(&mut self, _ctx: &mut SourceContext) {}
+    /// called when the source is stopped. This happens only once in the whole source lifecycle, as the very last callback
+    fn on_stop(&mut self, _ctx: &mut SourceContext) {}
+
+    // circuit breaker callbacks
+    /// called when we receive a `close` Circuit breaker event from any connected pipeline
+    /// Expected reaction is to pause receiving messages, which is handled automatically by the runtime
+    /// Source implementations might want to close connections or signal a pause to the upstream entity it connects to if not done in the connector (the default)
+    // TODO: add info of Cb event origin (port, origin_uri)?
+    fn on_cb_close(&mut self, _ctx: &mut SourceContext) {}
+    /// Called when we receive a `open` Circuit breaker event from any connected pipeline
+    /// This means we can start/continue polling this source for messages
+    /// Source implementations might want to start establishing connections if not done in the connector (the default)
+    fn on_cb_open(&mut self, _ctx: &mut SourceContext) {}
+
+    // guaranteed delivery callbacks
+    /// an event has been acknowledged and can be considered delivered
+    /// multiple acks for the same set of ids are always possible
+    fn ack(&mut self, _stream_id: u64, _pull_id: u64) {}
+    /// an event has failed along its way and can be considered failed
+    /// multiple fails for the same set of ids are always possible
+    fn fail(&mut self, _stream_id: u64, _pull_id: u64) {}
+
+    // connectivity stuff
+    /// called when connector lost connectivity
+    fn on_connection_lost(&mut self, _ctx: &mut SourceContext) {}
+    /// called when connector re-established connectivity
+    fn on_connection_established(&mut self, _ctx: &mut SourceContext) {}
+
+    /// Is this source transactional or can acks/fails be ignored
+    fn is_transactional(&self) -> bool {
+        false
+    }
+}
 
 /// source part of a connector
 #[async_trait::async_trait]
@@ -296,7 +367,8 @@ impl Source for ChannelSource {
 
 // TODO make fields private and add some nice methods
 /// context for a source
-#[derive(Clone)]
+#[repr(C)]
+#[derive(Clone, StableAbi)]
 pub struct SourceContext {
     /// connector uid
     pub uid: u64,
@@ -314,6 +386,8 @@ pub struct SourceAddr {
 }
 
 #[allow(clippy::module_name_repetitions)]
+#[repr(C)]
+#[derive(StableAbi)]
 pub struct SourceManagerBuilder {
     qsize: usize,
     streams: Streams,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,38 +21,7 @@ use crate::async_sink;
 use beef::Cow;
 use error_chain::error_chain;
 
-use hdrhistogram::{self, serialization as hdr_s};
 use tremor_influx as influx;
-
-impl From<sled::transaction::TransactionError<()>> for Error {
-    fn from(e: sled::transaction::TransactionError<()>) -> Self {
-        Self::from(format!("Sled Transaction Error: {:?}", e))
-    }
-}
-
-impl From<hdr_s::DeserializeError> for Error {
-    fn from(e: hdr_s::DeserializeError) -> Self {
-        Self::from(format!("{:?}", e))
-    }
-}
-
-impl From<hdrhistogram::errors::CreationError> for Error {
-    fn from(e: hdrhistogram::errors::CreationError) -> Self {
-        Self::from(format!("{:?}", e))
-    }
-}
-
-impl From<hdrhistogram::RecordError> for Error {
-    fn from(e: hdrhistogram::RecordError) -> Self {
-        Self::from(format!("{:?}", e))
-    }
-}
-
-impl From<hdrhistogram::serialization::V2SerializeError> for Error {
-    fn from(e: hdrhistogram::serialization::V2SerializeError) -> Self {
-        Self::from(format!("{:?}", e))
-    }
-}
 
 impl From<http_types::Error> for Error {
     fn from(e: http_types::Error) -> Self {
@@ -134,40 +103,28 @@ error_chain! {
         Base64Error(base64::DecodeError);
         ChannelReceiveError(std::sync::mpsc::RecvError);
         Common(tremor_common::Error);
-        CronError(cron::error::Error);
         DateTimeParseError(chrono::ParseError);
-        DnsError(async_std_resolver::ResolveError);
-        ElasticError(elastic::Error);
         FromUtf8Error(std::string::FromUtf8Error);
-        GoogleAuthError(gouth::Error);
-        HttpHeaderError(http::header::InvalidHeaderValue);
         InfluxEncoderError(influx::EncoderError);
         Io(std::io::Error);
         JsonAccessError(value_trait::AccessError);
         JsonError(simd_json::Error);
-        KafkaError(rdkafka::error::KafkaError);
         MsgPackDecoderError(rmp_serde::decode::Error);
         MsgPackEncoderError(rmp_serde::encode::Error);
         ParseIntError(std::num::ParseIntError);
         ParseFloatError(std::num::ParseFloatError);
-        Postgres(postgres::Error);
         RegexError(regex::Error);
-        ReqwestError(reqwest::Error);
-        RustlsError(rustls::TLSError);
         Hex(hex::FromHexError);
         SinkDequeueError(async_sink::SinkDequeueError);
         SinkEnqueueError(async_sink::SinkEnqueueError);
-        Sled(sled::Error);
         SnappyError(snap::Error);
         Timeout(async_std::future::TimeoutError);
-        TonicStatusError(tonic::Status);
-        TonicTransportError(tonic::transport::Error);
         TryFromIntError(std::num::TryFromIntError);
         UrlParserError(url::ParseError);
         Utf8Error(std::str::Utf8Error);
         ValueError(tremor_value::Error);
-        WsError(async_tungstenite::tungstenite::Error);
         YamlError(serde_yaml::Error) #[doc = "Error during yaml parsing"];
+        // TODO PluginError
     }
 
     errors {
@@ -312,3 +269,5 @@ error_chain! {
         }
     }
 }
+
+pub type RResult<T> = abi_stable::std_types::RResult<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// FIXME: temporary while PDK is WIP
+#![allow(unused_imports)]
 // Copyright 2020-2021, The Tremor Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,9 +36,6 @@ extern crate serde_derive;
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
-
-#[macro_use]
-extern crate rental;
 
 #[cfg(test)]
 #[macro_use]
@@ -92,6 +91,9 @@ pub mod version;
 
 /// Tremor connector extensions
 pub mod connectors;
+
+/// The plugin development kit
+pub mod pdk;
 
 pub(crate) mod common;
 

--- a/src/pdk/connectors.rs
+++ b/src/pdk/connectors.rs
@@ -1,0 +1,31 @@
+//! TODO: this should probably export a `ConnectorBuilder` instead.
+//! TODO: move into a separate crate along  with the `RawConnector` trait and
+//! similars.
+
+use crate::connectors::{ConnectorMod_Ref, RawConnector_TO};
+
+use abi_stable::{
+    declare_root_module_statics, package_version_strings, std_types::RBox, RootModule,
+};
+
+#[repr(C)]
+#[derive(StableAbi)]
+#[sabi(kind(Prefix))]
+pub struct ConnectorMod {
+    pub new: extern "C" fn() -> RawConnector_TO<'static, RBox<()>>,
+}
+
+// Marking `MinMod` as the main module in this plugin. Note that `MinMod_Ref` is
+// a pointer to the prefix of `MinMod`.
+impl RootModule for ConnectorMod_Ref {
+    // The name of the dynamic library
+    const BASE_NAME: &'static str = "connector";
+    // The name of the library for logging and similars
+    const NAME: &'static str = "connector";
+    // The version of this plugin's crate
+    const VERSION_STRINGS: VersionStrings = package_version_strings!();
+
+    // Implements the `RootModule::root_module_statics` function, which is the
+    // only required implementation for the `RootModule` trait.
+    declare_root_module_statics! {ConnectorMod_Ref}
+}

--- a/src/pdk/mod.rs
+++ b/src/pdk/mod.rs
@@ -1,0 +1,8 @@
+pub mod connectors;
+pub mod panic;
+
+use crate::errors::Error;
+
+use abi_stable::std_types::RBoxError;
+
+pub type RResult<T> = abi_stable::std_types::RResult<T, RBoxError>;

--- a/src/pdk/panic.rs
+++ b/src/pdk/panic.rs
@@ -1,0 +1,50 @@
+//! Panic errors should be treated differently from a regular error. Apart from
+//! the fact that `panic::catch_unwind` returns a `Box<dyn Any>`, which is not
+//! compatible with a `Box<dyn Error>`, panics happen when the plugin reaches an
+//! unrecoverable state and cannot continue.
+//!
+//! Instead of using `RResult` for panics, `MayPanic` is a different type that
+//! only returns the original type if the function finished without panicking.
+//! Since the contents returned by `catch_unwind` are just `dyn Any` and don't
+//! provide much value, they're discarded.
+//!
+//! Hopefully we will be able to remove this workaround as soon as `C-unwind` is
+//! stabilized, as it may introduce some overhead:
+//!
+//! https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html
+
+use abi_stable::StableAbi;
+
+#[repr(C)]
+#[derive(Debug, StableAbi)]
+pub enum MayPanic<T> {
+    Panic,
+    NoPanic(T),
+}
+
+impl<T> MayPanic<T> {
+    /// NOTE: Until https://doc.rust-lang.org/std/ops/trait.Try.html is
+    /// stabilized.
+    pub fn unwrap(self) -> T {
+        match self {
+            MayPanic::Panic => panic!("unwrap: unhandled panic"),
+            MayPanic::NoPanic(t) => t,
+        }
+    }
+}
+
+impl<T: Default> Default for MayPanic<T> {
+    fn default() -> Self {
+        MayPanic::NoPanic(T::default())
+    }
+}
+
+/// For conversions from `catch_unwind` mostly
+impl<T> From<std::thread::Result<T>> for MayPanic<T> {
+    fn from(res: std::thread::Result<T>) -> Self {
+        match res {
+            Ok(val) => MayPanic::NoPanic(val),
+            Err(_) => MayPanic::Panic,
+        }
+    }
+}

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -20,30 +20,8 @@ use crate::url::TremorUrl;
 use async_std::channel::Sender;
 use halfbrown::HashMap;
 
-pub(crate) mod amqp;
-pub(crate) mod blackhole;
-pub(crate) mod cb;
-pub(crate) mod debug;
-pub(crate) mod dns;
-pub(crate) mod elastic;
-pub(crate) mod exit;
-pub(crate) mod file;
-pub(crate) mod gcs;
-pub(crate) mod gpub;
-pub(crate) mod kafka;
-pub(crate) mod kv;
-pub(crate) mod nats;
-pub(crate) mod newrelic;
-pub(crate) mod otel;
-pub(crate) mod postgres;
 /// lots of useful stuff in there
 pub(crate) mod prelude;
-pub(crate) mod rest;
-pub(crate) mod stderr;
-pub(crate) mod stdout;
-pub(crate) mod tcp;
-pub(crate) mod udp;
-pub(crate) mod ws;
 
 /// reply from a sink
 #[derive(Debug)]
@@ -346,72 +324,7 @@ where
 /// register buitlin sink types
 #[cfg(not(tarpaulin_include))]
 pub async fn register_builtin_sinks(world: &World) -> Result<()> {
-    world
-        .register_builtin_offramp_type("amqp", Box::new(amqp::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("blackhole", Box::new(blackhole::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("cb", Box::new(cb::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("debug", Box::new(debug::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("dns", Box::new(dns::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("elastic", Box::new(elastic::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("exit", Box::new(exit::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("file", Box::new(file::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("gcs", Box::new(gcs::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("gpub", Box::new(gpub::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("kafka", Box::new(kafka::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("kv", Box::new(kv::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("nats", Box::new(nats::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("newrelic", Box::new(newrelic::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("otel", Box::new(otel::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("postgres", Box::new(postgres::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("rest", Box::new(rest::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("stderr", Box::new(stderr::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("stdout", Box::new(stdout::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("tcp", Box::new(tcp::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("udp", Box::new(udp::Builder {}))
-        .await?;
-    world
-        .register_builtin_offramp_type("ws", Box::new(ws::Builder {}))
-        .await?;
+    // TODO load dynamically
     Ok(())
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -38,27 +38,8 @@ use tremor_script::prelude::*;
 
 use self::prelude::OnrampConfig;
 
-pub(crate) mod amqp;
-pub(crate) mod blaster;
-pub(crate) mod cb;
-pub(crate) mod crononome;
-pub(crate) mod discord;
-pub(crate) mod env;
-pub(crate) mod file;
-pub(crate) mod gsub;
-pub(crate) mod kafka;
-pub(crate) mod metronome;
-pub(crate) mod nats;
-pub(crate) mod otel;
-pub(crate) mod postgres;
 /// prelude full of useful stuff
 pub(crate) mod prelude;
-pub(crate) mod rest;
-pub(crate) mod sse;
-pub(crate) mod stdin;
-pub(crate) mod tcp;
-pub(crate) mod udp;
-pub(crate) mod ws;
 
 struct StaticValue(Value<'static>);
 
@@ -666,63 +647,7 @@ where
 /// register builtin source types
 #[cfg(not(tarpaulin_include))]
 pub async fn register_builtin_sources(world: &World) -> Result<()> {
-    world
-        .register_builtin_onramp_type("amqp", Box::new(amqp::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("blaster", Box::new(blaster::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("cb", Box::new(cb::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("crononome", Box::new(crononome::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("discord", Box::new(discord::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("env", Box::new(env::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("file", Box::new(file::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("gsub", Box::new(gsub::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("kafka", Box::new(kafka::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("metronome", Box::new(metronome::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("nats", Box::new(nats::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("otel", Box::new(otel::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("postgres", Box::new(postgres::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("rest", Box::new(rest::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("sse", Box::new(sse::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("stdin", Box::new(stdin::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("tcp", Box::new(tcp::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("udp", Box::new(udp::Builder {}))
-        .await?;
-    world
-        .register_builtin_onramp_type("ws", Box::new(ws::Builder {}))
-        .await?;
+    // TODO load dynamically
     Ok(())
 }
 

--- a/src/url.rs
+++ b/src/url.rs
@@ -14,10 +14,12 @@
 
 use crate::errors::{Error, ErrorKind, Result};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use abi_stable::{StableAbi, std_types::{RString, ROption}};
 use std::fmt;
 
 /// The type or resource the url references
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[repr(C)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug, StableAbi)]
 pub enum ResourceType {
     /// This is a pipeline
     Pipeline,
@@ -32,7 +34,8 @@ pub enum ResourceType {
 }
 
 /// The scrope of the URL
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[repr(C)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug, StableAbi)]
 pub enum Scope {
     /// This URL identifies a specific port
     Port,
@@ -64,14 +67,15 @@ pub mod ports {
 /// A tremor URL identifying an entity in tremor
 
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+#[repr(C)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, StableAbi)]
 pub struct TremorUrl {
     scope: Scope,
-    host: String,
-    resource_type: Option<ResourceType>,
-    artefact: Option<String>,
-    instance: Option<String>,
-    instance_port: Option<String>,
+    host: RString,
+    resource_type: ROption<ResourceType>,
+    artefact: ROption<RString>,
+    instance: ROption<RString>,
+    instance_port: ROption<RString>,
 }
 
 fn decode_type(t: &str) -> Result<ResourceType> {

--- a/src/url.rs
+++ b/src/url.rs
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 use crate::errors::{Error, ErrorKind, Result};
+use abi_stable::{
+    std_types::{ROption, RString},
+    StableAbi,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use abi_stable::{StableAbi, std_types::{RString, ROption}};
 use std::fmt;
 
 /// The type or resource the url references

--- a/src/version.rs
+++ b/src/version.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rdkafka::util::get_rdkafka_version;
 /// Version of the tremor crate;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -44,22 +43,11 @@ pub fn long_ver() -> String {
 pub fn print() {
     eprintln!("tremor version: {}", long_ver().as_str());
     eprintln!("tremor instance: {}", instance!());
-    let (version_n, version_s) = get_rdkafka_version();
-    eprintln!("rd_kafka version: 0x{:08x}, {}", version_n, version_s);
 }
 
 /// Logs tremor and librdkafka version.
 pub fn log() {
     info!("tremor version: {}", long_ver().as_str());
-    let (version_n, version_s) = get_rdkafka_version();
-    info!("rd_kafka version: 0x{:08x}, {}", version_n, version_s);
-}
-
-/// Gets the librdkafka version string
-#[must_use]
-pub fn rdkafka() -> String {
-    let (_, version) = get_rdkafka_version();
-    version
 }
 
 #[cfg(test)]

--- a/tremor-value/src/value.rs
+++ b/tremor-value/src/value.rs
@@ -1335,7 +1335,8 @@ mod test {
             |inner| {
                 prop_oneof![
                     // Take the inner strategy and make the two recursive cases.
-                    prop::collection::vec(inner.clone(), 0..10).prop_map(|a| Value::Array(a.into())),
+                    prop::collection::vec(inner.clone(), 0..10)
+                        .prop_map(|a| Value::Array(a.into())),
                     prop::collection::hash_map(".*".prop_map(RCow::from), inner, 0..10)
                         .prop_map(|m| m.into_iter().collect()),
                 ]
@@ -1368,7 +1369,8 @@ mod test {
             |inner| {
                 prop_oneof![
                     // Take the inner strategy and make the two recursive cases.
-                    prop::collection::vec(inner.clone(), 0..10).prop_map(|a| Value::Array(a.into())),
+                    prop::collection::vec(inner.clone(), 0..10)
+                        .prop_map(|a| Value::Array(a.into())),
                     prop::collection::hash_map(".*".prop_map(RCow::from), inner, 0..10)
                         .prop_map(|m| m.into_iter().collect()),
                 ]


### PR DESCRIPTION
# Pull request

## Description

Based on the work in https://github.com/tremor-rs/tremor-runtime/pull/1303, this tries to do the same but for the main `tremor-runtime` crate.

Once this is more or less acceptable, it should be merged into the `connectors` branch to avoid more conflicts and to start working on these together.

## Related

* [RFC](https://www.tremor.rs/rfc/accepted/plugin-development-kit)
* Related Issues: #791 #1077
* Related docs: https://nullderef.com/series/rust-plugins/

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

Custom checklist:
* [ ] Panicking or aborting?
* [ ] Cleaning up `simd_json::Value` in `OpMeta`
* [ ] Supporting `StableAbi` derive in `value_trait`

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


I do have a few benchmarks so far in https://github.com/marioortizmanero/pdk-experiments, which I will analyze in a new post on nullderef.com. These do not represent a real usage of Tremor, however, so I will make a few more once everything is working properly.