### PR TITLE
Adding `abi_stable` support for `tremor-script`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6804,6 +6804,7 @@ dependencies = [
 name = "tremor-script"
 version = "0.11.4"
 dependencies = [
+ "abi_stable",
  "atty",
  "base64 0.13.0",
  "beef",

--- a/tremor-script/Cargo.toml
+++ b/tremor-script/Cargo.toml
@@ -21,6 +21,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 name = "tremor_script"
 
 [dependencies]
+abi_stable = { version = "0.10.3", default-features = false }
 atty = "0.2"
 base64 = "0.13"
 beef = { version="0.5", features=["impl_serde"] }
@@ -58,7 +59,7 @@ tremor-kv = "0.2"
 tremor-value = { version="0.3", path="../tremor-value" }
 unicode-xid = "0.2"
 url = "2"
-value-trait = "0.2"
+value-trait = { version = "0.2.9", features = ["c-abi"] }
 xz2 = "0.1"
 
 [build-dependencies]

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -50,7 +50,6 @@ use crate::{
 };
 pub(crate) use analyzer::*;
 pub use base_expr::BaseExpr;
-use beef::Cow;
 use halfbrown::HashMap;
 pub use query::*;
 use serde::Serialize;

--- a/tremor-script/src/ast/raw.rs
+++ b/tremor-script/src/ast/raw.rs
@@ -38,10 +38,10 @@ use crate::{
     KnownKey, Value,
 };
 pub use base_expr::BaseExpr;
-use beef::Cow;
 use halfbrown::HashMap;
 pub use query::*;
 use serde::Serialize;
+use abi_stable::std_types::RCow;
 
 /// A raw script we got to put this here because of silly lalrpoop focing it to be public
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -338,7 +338,7 @@ impl<'script> ModuleRaw<'script> {
 pub struct IdentRaw<'script> {
     pub start: Location,
     pub end: Location,
-    pub id: beef::Cow<'script, str>,
+    pub id: RCow<'script, str>,
 }
 impl_expr!(IdentRaw);
 impl<'script> ToString for IdentRaw<'script> {
@@ -1483,16 +1483,16 @@ pub enum PredicatePatternRaw<'script> {
     /// we're forced to make this pub because of lalrpop
     TildeEq {
         /// we're forced to make this pub because of lalrpop
-        assign: Cow<'script, str>,
+        assign: RCow<'script, str>,
         /// we're forced to make this pub because of lalrpop
-        lhs: Cow<'script, str>,
+        lhs: RCow<'script, str>,
         /// we're forced to make this pub because of lalrpop
         test: TestExprRaw,
     },
     /// we're forced to make this pub because of lalrpop
     Bin {
         /// we're forced to make this pub because of lalrpop
-        lhs: Cow<'script, str>,
+        lhs: RCow<'script, str>,
         /// we're forced to make this pub because of lalrpop
         rhs: ImutExprRaw<'script>,
         /// we're forced to make this pub because of lalrpop
@@ -1501,26 +1501,26 @@ pub enum PredicatePatternRaw<'script> {
     /// we're forced to make this pub because of lalrpop
     RecordPatternEq {
         /// we're forced to make this pub because of lalrpop
-        lhs: Cow<'script, str>,
+        lhs: RCow<'script, str>,
         /// we're forced to make this pub because of lalrpop
         pattern: RecordPatternRaw<'script>,
     },
     /// we're forced to make this pub because of lalrpop
     ArrayPatternEq {
         /// we're forced to make this pub because of lalrpop
-        lhs: Cow<'script, str>,
+        lhs: RCow<'script, str>,
         /// we're forced to make this pub because of lalrpop
         pattern: ArrayPatternRaw<'script>,
     },
     /// we're forced to make this pub because of lalrpop
     FieldPresent {
         /// we're forced to make this pub because of lalrpop
-        lhs: Cow<'script, str>,
+        lhs: RCow<'script, str>,
     },
     /// we're forced to make this pub because of lalrpop
     FieldAbsent {
         /// we're forced to make this pub because of lalrpop
-        lhs: Cow<'script, str>,
+        lhs: RCow<'script, str>,
     },
 }
 

--- a/tremor-script/src/grammar.lalrpop
+++ b/tremor-script/src/grammar.lalrpop
@@ -19,7 +19,7 @@ use crate::lexer::Token;
 use crate::pos::Location;
 use crate::Value;
 use crate::prelude::*;
-use beef::Cow;
+use abi_stable::std_types::RCow;
 
 grammar<'input>;
 
@@ -263,11 +263,11 @@ pub(crate) Script : ScriptRaw<'input> = {
   <doc:ModComment> <exprs:Exprs> "<end-of-stream>"? => ScriptRaw::new(exprs, doc),
 }
 
-ModComment: Option<Vec<Cow<'input, str>>> = {
+ModComment: Option<Vec<RCow<'input, str>>> = {
     (<ModComment_>)? => <>
 }
 
-ModComment_: Vec<Cow<'input, str>> = {
+ModComment_: Vec<RCow<'input, str>> = {
     <c:"<mod-comment>"> => vec![c.into()],
     <v:ModComment_> <c:"<mod-comment>"> => {
         let mut v = v;
@@ -299,10 +299,10 @@ Const: ExprRaw<'input> = {
     <comment:DocComment> <start:@L> "const" <name:Ident> @L "=" @R <expr:SimpleExprImut> <end:@L> => ExprRaw::Const{name: name.id, expr: expr, start, end, comment},
 }
 
-DocComment: Option<Vec<Cow<'input, str>>> = {
+DocComment: Option<Vec<RCow<'input, str>>> = {
     (<DocComment_>)? => <>
 }
-DocComment_: Vec<Cow<'input, str>> = {
+DocComment_: Vec<RCow<'input, str>> = {
     <c:"<doc-comment>"> => vec![c.into()],
     <v:DocComment_> <c:"<doc-comment>"> => {
         let mut v = v;
@@ -690,7 +690,7 @@ StrLitElements: StrLitElementsRaw<'input> = {
     "#{" <expr:ExprImut> "}" => vec![expr.into()],
 }
 
-StringPart: Cow<'input, str> = {
+StringPart: RCow<'input, str> = {
     "string" => <>,
     "heredoc" => <>
 }
@@ -1387,12 +1387,12 @@ extern {
         "bool" => Token::BoolLiteral(<bool>),
         "int" => Token::IntLiteral(<i64>),
         "float" => Token::FloatLiteral(<f64>, <String>),
-        "string" => Token::StringLiteral(<Cow<'input, str>>),
+        "string" => Token::StringLiteral(<RCow<'input, str>>),
         "heredoc_start" => Token::HereDocStart,
         "heredoc_end" => Token::HereDocEnd,
-        "heredoc" => Token::HereDocLiteral(<Cow<'input, str>>),
+        "heredoc" => Token::HereDocLiteral(<RCow<'input, str>>),
         "<extractor>" => Token::TestLiteral(_, <Vec<String>>),
-        "<ident>" => Token::Ident(<Cow<'input, str>>, <bool>),
+        "<ident>" => Token::Ident(<RCow<'input, str>>, <bool>),
         "<error>" => Token::Bad(<String>),
         "<end-of-stream>" => Token::EndOfStream,
         "<newline>" => Token::NewLine,

--- a/tremor-script/src/interpreter.rs
+++ b/tremor-script/src/interpreter.rs
@@ -747,32 +747,32 @@ where
 ///
 enum PreEvaluatedPatchOperation<'event, 'run> {
     Insert {
-        ident: beef::Cow<'event, str>,
+        ident: RCow<'event, str>,
         ident_expr: &'run StringLit<'event>,
         value: Value<'event>,
     },
     Update {
-        ident: beef::Cow<'event, str>,
+        ident: RCow<'event, str>,
         ident_expr: &'run StringLit<'event>,
         value: Value<'event>,
     },
     Upsert {
-        ident: beef::Cow<'event, str>,
+        ident: RCow<'event, str>,
         value: Value<'event>,
     },
     Erase {
-        ident: beef::Cow<'event, str>,
+        ident: RCow<'event, str>,
     },
     Copy {
-        from: beef::Cow<'event, str>,
-        to: beef::Cow<'event, str>,
+        from: RCow<'event, str>,
+        to: RCow<'event, str>,
     },
     Move {
-        from: beef::Cow<'event, str>,
-        to: beef::Cow<'event, str>,
+        from: RCow<'event, str>,
+        to: RCow<'event, str>,
     },
     Merge {
-        ident: beef::Cow<'event, str>,
+        ident: RCow<'event, str>,
         ident_expr: &'run StringLit<'event>,
         merge_value: Value<'event>,
     },
@@ -780,7 +780,7 @@ enum PreEvaluatedPatchOperation<'event, 'run> {
         merge_value: Value<'event>,
     },
     Default {
-        ident: beef::Cow<'event, str>,
+        ident: RCow<'event, str>,
         expr: &'run ImutExprInt<'event>,
     },
     DefaultRecord {

--- a/tremor-script/src/interpreter/expr.rs
+++ b/tremor-script/src/interpreter/expr.rs
@@ -36,6 +36,7 @@ use std::{
     borrow::{Borrow, Cow},
     iter,
 };
+use abi_stable::std_types::{RBox, Tuple2};
 #[derive(Debug)]
 /// Continuation context to control program flow
 pub enum Cont<'run, 'event>
@@ -345,11 +346,11 @@ impl<'script> Expr<'script> {
         let (l, items): Bi = t.as_object().map_or_else(
             || {
                 t.as_array().map_or_else::<Bi, _, _>(
-                    || (0, Box::new(iter::empty())),
-                    |t| (t.len(), Box::new(t.clone().into_iter().enumerate().map(kv))),
+                    || Tuple2(0, RBox::new(iter::empty())),
+                    |t| Tuple2(t.len(), RBox::new(t.clone().into_iter().enumerate().map(kv))),
                 )
             },
-            |t| (t.len(), Box::new(t.clone().into_iter().map(kv))),
+            |t| Tuple2(t.len(), RBox::new(t.clone().into_iter().map(kv))),
         );
 
         if opts.result_needed {
@@ -497,7 +498,7 @@ impl<'script> Expr<'script> {
                     current = match map.get_mut(&id) {
                         Some(v) => v,
                         None => map
-                            .entry(id)
+                            .entry(id.into())
                             .or_insert_with(|| Value::object_with_capacity(32)),
                     };
                 }

--- a/tremor-script/src/interpreter/imut_expr.rs
+++ b/tremor-script/src/interpreter/imut_expr.rs
@@ -35,6 +35,7 @@ use std::{
     borrow::{Borrow, Cow},
     iter, mem,
 };
+use abi_stable::std_types::Tuple2;
 
 impl<'script> ImutExpr<'script> {
     /// Evaluates the expression
@@ -293,7 +294,7 @@ impl<'script> ImutExprInt<'script> {
             |t| {
                 (
                     t.len(),
-                    Box::new(t.iter().map(|(k, v)| (k.clone().into(), v.clone()))),
+                    Box::new(t.iter().map(|Tuple2(k, v)| (k.clone().into(), v.clone()))),
                 )
             },
         );

--- a/tremor-script/src/registry/custom_fn.rs
+++ b/tremor-script/src/registry/custom_fn.rs
@@ -17,11 +17,11 @@ use crate::ast::{Expr, Exprs, FnDecl, ImutExpr, ImutExprInt, ImutExprs, InvokeAg
 use crate::interpreter::{AggrType, Cont, Env, ExecOpts, LocalStack};
 use crate::prelude::*;
 use crate::Value;
-use beef::Cow;
+use abi_stable::std_types::RCow;
 //use std::mem;
 const RECUR_STR: &str = "recur";
 pub(crate) const RECUR_PTR: Option<*const u8> = Some(RECUR_STR.as_ptr());
-pub(crate) const RECUR: Value<'static> = Value::String(Cow::const_str(RECUR_STR));
+pub(crate) const RECUR: Value<'static> = Value::String(RCow::const_str(RECUR_STR));
 pub(crate) const RECUR_REF: &Value<'static> = &RECUR;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/tremor-script/src/std_lib/binary.rs
+++ b/tremor-script/src/std_lib/binary.rs
@@ -15,6 +15,7 @@
 use crate::prelude::*;
 use crate::registry::Registry;
 use crate::{tremor_const_fn, tremor_fn_};
+use abi_stable::std_types::RCow;
 
 pub fn load(registry: &mut Registry) {
     registry
@@ -23,7 +24,7 @@ pub fn load(registry: &mut Registry) {
         }))
         .insert(
             tremor_const_fn! (binary|from_bytes(_context, _input: Array) {
-                _input.iter().map(|v| v.as_u8().ok_or_else(||to_runtime_error("array contains non bytes"))).collect::<FResult<Vec<u8>>>().map(beef::Cow::from).map(Value::Bytes)
+                _input.iter().map(|v| v.as_u8().ok_or_else(||to_runtime_error("array contains non bytes"))).collect::<FResult<Vec<u8>>>().map(RCow::from).map(Value::Bytes)
             }),
         ).insert(
             tremor_const_fn! (binary|into_bytes(_context, input) {

--- a/tremor-script/src/std_lib/record.rs
+++ b/tremor-script/src/std_lib/record.rs
@@ -16,6 +16,7 @@ use crate::prelude::*;
 use crate::registry::Registry;
 use crate::tremor_const_fn;
 use crate::Object;
+use abi_stable::std_types::Tuple2;
 
 pub fn load(registry: &mut Registry) {
     registry
@@ -40,7 +41,7 @@ pub fn load(registry: &mut Registry) {
         .insert(tremor_const_fn! (record|to_array(_context, _input: Object) {
             Ok(Value::from(
                 _input.iter()
-                    .map(|(k, v)| Value::from(vec![Value::from(k.clone()), v.clone()]))
+                    .map(|Tuple2(k, v)| Value::from(vec![Value::from(k.clone()), v.clone()]))
                     .collect::<Vec<_>>(),
             ))
         }))
@@ -63,7 +64,7 @@ pub fn load(registry: &mut Registry) {
         Ok(Value::from(r?))
         })).insert(tremor_const_fn!(record|select(_context, _input: Object, _keys: Array) {
         let keys: Vec<_> = _keys.iter().filter_map(ValueAccess::as_str).collect();
-        let r: Object =_input.iter().filter_map(|(k, v)| {
+        let r: Object =_input.iter().filter_map(|Tuple2(k, v)| {
             let k: &str = k;
             if keys.contains(&k) {
                 Some((k.to_string().into(), v.clone()))
@@ -74,9 +75,9 @@ pub fn load(registry: &mut Registry) {
         Ok(Value::from(r))
     }))
         .insert(tremor_const_fn!(record|merge(_context, _left: Object, _right: Object) {
-        Ok(Value::from(_left.iter().chain(_right.iter()).map(|(k, v)| (k.clone(), v.clone())).collect::<Object>()))
+        Ok(Value::from(_left.iter().chain(_right.iter()).map(|Tuple2(k, v)| (k.clone(), v.clone())).collect::<Object>()))
         })).insert(tremor_const_fn!(record|rename(_context, _target: Object, _renameings: Object) {
-            Ok(Value::from(_target.iter().map(|(k, v)| if let Some(Value::String(k1)) = _renameings.get(k) {
+            Ok(Value::from(_target.iter().map(|Tuple2(k, v)| if let Some(Value::String(k1)) = _renameings.get(k) {
                 (k1.clone(), v.clone())
             } else {
                 (k.clone(), v.clone())

--- a/tremor-script/src/std_lib/win.rs
+++ b/tremor-script/src/std_lib/win.rs
@@ -163,7 +163,7 @@ impl TremorAggrFn for CollectNested {
     //     Ok(())
     // }
     fn emit<'event>(&mut self) -> FResult<Value<'event>> {
-        Ok(Value::Array(self.0.clone()))
+        Ok(Value::Array(self.0.clone().into()))
     }
     fn emit_and_init<'event>(&mut self) -> FResult<Value<'event>> {
         let mut r = Vec::with_capacity(self.0.len());
@@ -178,7 +178,8 @@ impl TremorAggrFn for CollectNested {
         if let Some(other) = src.downcast_ref::<Self>() {
             // On self is earlier then other, so as long
             // as other has a value we take it
-            self.0.push(Value::from(other.0.clone()));
+            let other: RVec<_> = other.0.clone().into();
+            self.0.push(Value::from(other));
         }
         Ok(())
     }

--- a/tremor-script/src/tilde.rs
+++ b/tremor-script/src/tilde.rs
@@ -40,6 +40,7 @@ use std::iter::{Iterator, Peekable};
 use std::net::{IpAddr, Ipv4Addr};
 use std::slice::Iter;
 use std::str::FromStr;
+use abi_stable::std_types::{RHashMap, RCow};
 use tremor_influx as influx;
 use tremor_kv as kv;
 
@@ -594,7 +595,7 @@ impl Extractor {
 
                 Self::Re { compiled, .. } => compiled.captures(s).map_or(NoMatch, |caps| {
                     if result_needed {
-                        let matches: HashMap<beef::Cow<str>, Value> = compiled
+                        let matches: RHashMap<RCow<str>, Value> = compiled
                             .capture_names()
                             .flatten()
                             .filter_map(|n| {

--- a/tremor-script/src/tilde.rs
+++ b/tremor-script/src/tilde.rs
@@ -23,7 +23,6 @@
 //  '{}' -> json|| => Ok({})
 //  Predicate for json||: "is valid json"
 //  '{blarg' -> json|| =>
-use halfbrown::{hashmap, HashMap};
 
 use crate::prelude::*;
 use crate::{datetime, grok::Pattern as GrokPattern, EventContext, Object, Value};
@@ -682,18 +681,22 @@ impl std::ops::Deref for Cidr {
 }
 
 impl<'cidr> From<Cidr>
-    for HashMap<Cow<'cidr, str>, Value<'cidr>, BuildHasherDefault<fxhash::FxHasher>>
+    for RHashMap<RCow<'cidr, str>, Value<'cidr>>
 {
     fn from(x: Cidr) -> Self {
         match x.0 {
-            IpCidr::V4(y) => hashmap!(
-                       "prefix".into() => Value::from(y.get_prefix_as_u8_array().to_vec()),
-                       "mask".into() => Value::from(y.get_mask_as_u8_array().to_vec()),
-            ),
-            IpCidr::V6(y) => hashmap!(
-                       "prefix".into() => Value::from(y.get_prefix_as_u16_array().to_vec()),
-                       "mask".into() => Value::from(y.get_mask_as_u16_array().to_vec()),
-            ),
+            IpCidr::V4(y) => {
+                let mut map = RHashMap::with_capacity(2);
+                map.insert("prefix".into(), Value::from(y.get_prefix_as_u8_array().to_vec()));
+                map.insert("mask".into(), Value::from(y.get_mask_as_u8_array().to_vec()));
+                map
+            },
+            IpCidr::V6(y) => {
+                let mut map = RHashMap::with_capacity(2);
+                map.insert("prefix".into(), Value::from(y.get_prefix_as_u16_array().to_vec()));
+                map.insert("mask".into(), Value::from(y.get_mask_as_u16_array().to_vec()));
+                map
+            },
         }
     }
 }

--- a/tremor-script/src/utils.rs
+++ b/tremor-script/src/utils.rs
@@ -16,6 +16,7 @@ use crate::errors::{Error, ErrorKind, Result};
 use crate::prelude::*;
 use crate::Value;
 use std::{io::prelude::*, path::Path};
+use abi_stable::std_types::Tuple2;
 
 /// Fetches a hostname with `tremor-host.local` being the default
 #[must_use]
@@ -62,7 +63,7 @@ fn sorted_serialize_<'v, W: Write>(j: &Value<'v>, w: &mut W) -> Result<()> {
         }
         Value::Object(o) => {
             let mut v: Vec<(String, Value<'v>)> =
-                o.iter().map(|(k, v)| (k.to_string(), v.clone())).collect();
+                o.iter().map(|Tuple2(k, v)| (k.to_string(), v.clone())).collect();
 
             v.sort_by_key(|(k, _)| k.to_string());
             let mut iter = v.into_iter();


### PR DESCRIPTION
# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


