### PR TITLE
Experimenting w lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,6 @@ version = 3
 [[package]]
 name = "abi_stable"
 version = "0.10.3"
-source = "git+https://github.com/marioortizmanero/abi_stable_crates.git?branch=rvec-append#1946b2b79b4074882a6812f1c0dd28b66eeffdcf"
 dependencies = [
  "abi_stable_derive",
  "abi_stable_shared",
@@ -13,7 +12,7 @@ dependencies = [
  "generational-arena",
  "libloading",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.11.2",
  "paste",
  "repr_offset",
  "rustc_version 0.4.0",
@@ -24,7 +23,6 @@ dependencies = [
 [[package]]
 name = "abi_stable_derive"
 version = "0.10.3"
-source = "git+https://github.com/marioortizmanero/abi_stable_crates.git?branch=rvec-append#1946b2b79b4074882a6812f1c0dd28b66eeffdcf"
 dependencies = [
  "abi_stable_shared",
  "as_derive_utils",
@@ -39,7 +37,6 @@ dependencies = [
 [[package]]
 name = "abi_stable_shared"
 version = "0.10.3"
-source = "git+https://github.com/marioortizmanero/abi_stable_crates.git?branch=rvec-append#1946b2b79b4074882a6812f1c0dd28b66eeffdcf"
 dependencies = [
  "core_extensions",
 ]
@@ -227,7 +224,6 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "as_derive_utils"
 version = "0.10.3"
-source = "git+https://github.com/marioortizmanero/abi_stable_crates.git?branch=rvec-append#1946b2b79b4074882a6812f1c0dd28b66eeffdcf"
 dependencies = [
  "core_extensions",
  "proc-macro2",
@@ -286,14 +282,14 @@ dependencies = [
  "futures-io",
  "once_cell",
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
 name = "async-compression"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
+checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
 dependencies = [
  "bytes 0.5.6",
  "flate2",
@@ -301,7 +297,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "xz2",
 ]
 
@@ -363,7 +359,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "tokio 0.3.7",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -396,7 +392,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2 0.4.3",
+ "socket2 0.4.4",
  "waker-fn",
  "winapi 0.3.9",
 ]
@@ -558,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
 
 [[package]]
 name = "async-tls"
@@ -609,7 +605,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project 1.0.10",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-rustls 0.22.0",
  "tungstenite 0.11.1",
  "webpki-roots 0.20.0",
@@ -730,7 +726,7 @@ dependencies = [
  "hyper 0.14.16",
  "hyper-rustls 0.22.1",
  "pin-project 1.0.10",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tower",
  "tracing",
 ]
@@ -789,7 +785,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "ring",
- "time 0.3.6",
+ "time 0.3.7",
  "tracing",
 ]
 
@@ -800,7 +796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969717af8b7eb7424b67fce3f3c8539b0cf72322f909a30d7ea9e8c5ed2bf929"
 dependencies = [
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -822,7 +818,7 @@ dependencies = [
  "lazy_static",
  "pin-project 1.0.10",
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tower",
  "tracing",
 ]
@@ -854,7 +850,7 @@ dependencies = [
  "hyper 0.14.16",
  "percent-encoding",
  "pin-project 1.0.10",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-util 0.6.9",
  "tracing",
 ]
@@ -883,7 +879,7 @@ dependencies = [
  "itoa 0.4.8",
  "num-integer",
  "ryu",
- "time 0.3.6",
+ "time 0.3.7",
 ]
 
 [[package]]
@@ -911,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
@@ -1306,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
 dependencies = [
  "atty",
  "bitflags",
@@ -1323,18 +1319,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d044e9db8cd0f68191becdeb5246b7462e4cf0c069b19ae00d1bf3fa9889498d"
+checksum = "be4dabb7e2f006497e1da045feaa512acf0686f76b68d94925da2d9422dcb521"
 dependencies = [
- "clap 3.0.10",
+ "clap 3.0.13",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1693,7 +1689,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.3",
+ "socket2 0.4.4",
  "winapi 0.3.9",
 ]
 
@@ -1787,7 +1783,7 @@ dependencies = [
  "crossbeam-queue",
  "num_cpus",
  "serde",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -2476,15 +2472,14 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f16c88aa13d2656ef20d1c042086b8767bbe2bdb62526894275a1b062161b2e"
+checksum = "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
 dependencies = [
  "futures-channel",
  "futures-core",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2544,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -2556,7 +2551,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-util 0.6.9",
  "tracing",
 ]
@@ -2823,15 +2818,15 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.10",
+ "h2 0.3.11",
  "http",
  "http-body 0.4.4",
  "httparse",
  "httpdate 1.0.2",
  "itoa 0.4.8",
  "pin-project-lite 0.2.8",
- "socket2 0.4.3",
- "tokio 1.15.0",
+ "socket2 0.4.4",
+ "tokio 1.16.1",
  "tower-service",
  "tracing",
  "want",
@@ -2849,7 +2844,7 @@ dependencies = [
  "log",
  "rustls 0.19.1",
  "rustls-native-certs 0.5.0",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-rustls 0.22.0",
  "webpki 0.21.4",
 ]
@@ -2863,7 +2858,7 @@ dependencies = [
  "http",
  "hyper 0.14.16",
  "rustls 0.20.2",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-rustls 0.23.2",
 ]
 
@@ -2875,7 +2870,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper 0.14.16",
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-io-timeout",
 ]
 
@@ -3141,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "lapin"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0a8c145a248b1536cfa06890d480cda7982add59f77973ac7b03db47f349b5"
+checksum = "36c0eacc7b8880c2e73ab70e47c9f099ad81af6debde9353fdb11045c0ce716e"
 dependencies = [
  "amq-protocol",
  "async-task",
@@ -3151,7 +3146,7 @@ dependencies = [
  "futures-core",
  "log",
  "mio 0.7.14",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pinky-swear",
  "serde",
 ]
@@ -3256,15 +3251,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libflate"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16364af76ebb39b5869bb32c81fa93573267cd8c62bb3474e28d78fac3fb141e"
+checksum = "d2d57e534717ac3e0b8dc459fe338bdfb4e29d7eea8fd0926ba649ddd3f4765f"
 dependencies = [
  "adler32",
  "crc32fast",
@@ -3310,9 +3305,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -3349,7 +3344,7 @@ dependencies = [
  "libc",
  "log",
  "log-mdc",
- "parking_lot",
+ "parking_lot 0.11.2",
  "regex",
  "serde",
  "serde-value",
@@ -3598,7 +3593,7 @@ dependencies = [
  "nkeys",
  "nuid",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "regex",
  "rustls 0.19.1",
  "rustls-native-certs 0.5.0",
@@ -3784,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a1eb3a36534514077c1e079ada2fb170ef30c47d203aa6916138cf882ecd52"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
 dependencies = [
  "libc",
 ]
@@ -3909,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "p12"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a97f513ac60e90aec6d9db783b1924a25839a2635036a3ab64f2ca78cd4518"
+checksum = "79772115e8ed1bd4e466105212189433409be03c7339092314cc0e4b6f92e79f"
 dependencies = [
  "block-modes",
  "des",
@@ -3919,7 +3914,7 @@ dependencies = [
  "hmac 0.12.0",
  "lazy_static",
  "rc2",
- "sha-1 0.10.0",
+ "sha1 0.10.0",
  "yasna",
 ]
 
@@ -3937,7 +3932,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.0",
 ]
 
 [[package]]
@@ -3952,6 +3957,19 @@ dependencies = [
  "redox_syscall 0.2.10",
  "smallvec",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f4f894f3865f6c0e02810fc597300f34dc2510f66400da262d8ae10e75767d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.10",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4096,12 +4114,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinky-swear"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf8cda6f8e1500338634e4e3ce90ac59eb7929a1e088b6946c742be1cc44dc1"
+checksum = "c5ade3d5e4fa85586b4795e097180fd48447d39fb56e351bd889f1c9664291a8"
 dependencies = [
  "doc-comment",
- "parking_lot",
+ "parking_lot 0.12.0",
  "tracing",
 ]
 
@@ -4179,7 +4197,7 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "log",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-postgres",
 ]
 
@@ -4229,9 +4247,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty_assertions"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
+checksum = "76d5b548b725018ab5496482b45cb8bef21e9fed1858a6d674e3a8a0f0bb5d50"
 dependencies = [
  "ansi_term",
  "ctor",
@@ -4333,7 +4351,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which 4.2.2",
+ "which 4.2.4",
 ]
 
 [[package]]
@@ -4668,7 +4686,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.10",
+ "h2 0.3.11",
  "http",
  "http-body 0.4.4",
  "hyper 0.14.16",
@@ -4687,7 +4705,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.1",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-rustls 0.23.2",
  "tokio-util 0.6.9",
  "url",
@@ -4725,9 +4743,9 @@ dependencies = [
 
 [[package]]
 name = "rle-decode-fast"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rmp"
@@ -4977,9 +4995,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4990,9 +5008,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5021,9 +5039,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -5050,9 +5068,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5158,7 +5176,7 @@ dependencies = [
  "reqwest 0.11.9",
  "serde",
  "serde_json",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tracing",
  "typemap_rev",
  "url",
@@ -5171,7 +5189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -5200,23 +5218,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.1",
-]
-
-[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
 dependencies = [
  "sha1_smol",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cc229fb94bcb689ffc39bd4ded842f6ff76885efede7c6d1ffb62582878bea"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -5405,7 +5423,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -5469,9 +5487,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -5549,7 +5567,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha1",
+ "sha1 0.6.1",
  "syn",
 ]
 
@@ -5567,7 +5585,7 @@ checksum = "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.11.2",
  "phf_shared 0.8.0",
  "precomputed-hash",
 ]
@@ -5852,9 +5870,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -5909,9 +5927,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d54b9298e05179c335de2b9645d061255bcd5155f843b3e328d2cfe0a5b413"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
  "libc",
  "num_threads",
@@ -6006,9 +6024,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes 1.1.0",
  "libc",
@@ -6027,7 +6045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -6053,14 +6071,14 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "percent-encoding",
  "phf",
  "pin-project-lite 0.2.8",
  "postgres-protocol",
  "postgres-types",
- "socket2 0.4.3",
- "tokio 1.15.0",
+ "socket2 0.4.4",
+ "tokio 1.16.1",
  "tokio-util 0.6.9",
 ]
 
@@ -6071,7 +6089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls 0.19.1",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "webpki 0.21.4",
 ]
 
@@ -6082,7 +6100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
  "rustls 0.20.2",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "webpki 0.22.0",
 ]
 
@@ -6094,7 +6112,7 @@ checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -6132,7 +6150,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -6156,7 +6174,7 @@ dependencies = [
  "bytes 1.1.0",
  "futures-core",
  "futures-util",
- "h2 0.3.10",
+ "h2 0.3.11",
  "http",
  "http-body 0.4.4",
  "hyper 0.14.16",
@@ -6165,7 +6183,7 @@ dependencies = [
  "pin-project 1.0.10",
  "prost",
  "prost-derive",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util 0.6.9",
@@ -6215,7 +6233,7 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "rand 0.8.4",
  "slab",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
  "tokio-util 0.6.9",
  "tower-layer",
@@ -6307,7 +6325,7 @@ version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-std",
- "clap 3.0.10",
+ "clap 3.0.13",
  "clap_complete",
  "criterion",
  "difference",
@@ -6641,7 +6659,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot",
+ "parking_lot 0.11.2",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -6683,7 +6701,7 @@ dependencies = [
  "input_buffer",
  "log",
  "rand 0.7.3",
- "sha-1 0.9.8",
+ "sha-1",
  "url",
  "utf-8",
 ]
@@ -6702,7 +6720,7 @@ dependencies = [
  "log",
  "rand 0.8.4",
  "rustls 0.20.2",
- "sha-1 0.9.8",
+ "sha-1",
  "thiserror",
  "url",
  "utf-8",
@@ -7116,9 +7134,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",
@@ -7189,6 +7207,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb069ac8b2117d36924190469735767f0990833935ab430155e71a44bafe148"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
+
+[[package]]
 name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7257,9 +7318,9 @@ checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
 
 [[package]]
 name = "zeroize"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"
+checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,10 @@ rust-bert = { git = 'https://github.com/mfelsche/rust-bert.git', rev = '1140989'
 rust_tokenizers = { git = 'https://github.com/mfelsche/rust-tokenizers.git', rev = '5a7860d' }
 # FIXME: update to crates.io when this is added to a new version:
 # https://github.com/rodrimati1992/abi_stable_crates/pull/70
-abi_stable = { git = "https://github.com/marioortizmanero/abi_stable_crates.git", branch = "rvec-append" }
+# https://github.com/rodrimati1992/abi_stable_crates/pull/76
+# abi_stable = { git = "https://github.com/marioortizmanero/abi_stable_crates.git", branch = "rvec-append" }
+abi_stable = { git = "https://github.com/marioortizmanero/abi_stable_crates.git", branch = "tremor-patches" }
+# abi_stable = { path = "/home/mario/Programming/abi_stable_crates/abi_stable" }
 # FIXME: update to crates.io when this is added to a new version:
 # https://github.com/simd-lite/simd-json-derive/pull/9
 simd-json-derive = { git = "https://github.com/marioortizmanero/simd-json-derive.git", branch = "abi-stable" }

--- a/tremor-script/src/std_lib/win.rs
+++ b/tremor-script/src/std_lib/win.rs
@@ -18,6 +18,8 @@ use crate::{prelude::*, tremor_fn};
 
 use std::ops::RangeInclusive;
 
+use abi_stable::std_types::RVec;
+
 #[derive(Clone, Debug, Default)]
 struct First(Option<Value<'static>>);
 impl TremorAggrFn for First {
@@ -163,7 +165,7 @@ impl TremorAggrFn for CollectNested {
     //     Ok(())
     // }
     fn emit<'event>(&mut self) -> FResult<Value<'event>> {
-        Ok(Value::Array(self.0.clone().into()))
+        Ok(Value::Array(RVec::from(self.0.clone())))
     }
     fn emit_and_init<'event>(&mut self) -> FResult<Value<'event>> {
         let mut r = Vec::with_capacity(self.0.len());

--- a/tremor-script/src/std_lib/win.rs
+++ b/tremor-script/src/std_lib/win.rs
@@ -163,7 +163,7 @@ impl TremorAggrFn for CollectNested {
     //     Ok(())
     // }
     fn emit<'event>(&mut self) -> FResult<Value<'event>> {
-        Ok(Value::Array(self.0.clone()))
+        Ok(Value::Array(self.0.clone().into()))
     }
     fn emit_and_init<'event>(&mut self) -> FResult<Value<'event>> {
         let mut r = Vec::with_capacity(self.0.len());

--- a/tremor-value/src/lib.rs
+++ b/tremor-value/src/lib.rs
@@ -52,6 +52,8 @@ use simd_json::Node;
 use simd_json_derive::{Deserialize, Serialize, Tape};
 use value_trait::Writable;
 
+use abi_stable::std_types::RVec;
+
 impl<'value> Serialize for Value<'value> {
     fn json_write<W>(&self, writer: &mut W) -> std::io::Result<()>
     where
@@ -80,7 +82,7 @@ impl<'input, 'tape> ValueDeser<'input, 'tape> {
         // Rust doesn't optimize the normal loop away here
         // so we write our own avoiding the length
         // checks during push
-        let mut res = Vec::with_capacity(len);
+        let mut res = RVec::with_capacity(len);
         unsafe {
             res.set_len(len);
             for i in 0..len {

--- a/tremor-value/src/serde/value/de.rs
+++ b/tremor-value/src/serde/value/de.rs
@@ -22,6 +22,8 @@ use serde_ext::forward_to_deserialize_any;
 use simd_json::StaticNode;
 use std::fmt;
 
+use abi_stable::std_types::RVec;
+
 impl<'de> de::Deserializer<'de> for Value<'de> {
     type Error = Error;
 
@@ -531,7 +533,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     {
         let size = seq.size_hint().unwrap_or_default();
 
-        let mut v = Vec::with_capacity(size);
+        let mut v = RVec::with_capacity(size);
         while let Some(e) = seq.next_element()? {
             v.push(e);
         }

--- a/tremor-value/src/serde/value/se.rs
+++ b/tremor-value/src/serde/value/se.rs
@@ -308,7 +308,7 @@ impl serde::ser::SerializeSeq for SerializeVec {
     }
 
     fn end(self) -> Result<Value<'static>> {
-        Ok(Value::Array(self.vec))
+        Ok(Value::Array(self.vec.into()))
     }
 }
 
@@ -359,7 +359,7 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     fn end(self) -> Result<Value<'static>> {
         let mut object = Object::with_capacity(1);
 
-        object.insert(self.name.into(), Value::Array(self.vec));
+        object.insert(self.name.into(), Value::Array(self.vec.into()));
 
         Ok(Value::from(object))
     }

--- a/tremor-value/src/serde/value/se.rs
+++ b/tremor-value/src/serde/value/se.rs
@@ -18,6 +18,8 @@ use serde_ext::ser::{
 };
 use simd_json::{stry, StaticNode};
 
+use abi_stable::std_types::RVec;
+
 type Impossible<T> = ser::Impossible<T, Error>;
 
 impl<'value> Serialize for Value<'value> {
@@ -308,7 +310,7 @@ impl serde::ser::SerializeSeq for SerializeVec {
     }
 
     fn end(self) -> Result<Value<'static>> {
-        Ok(Value::Array(self.vec.into()))
+        Ok(Value::Array(RVec::from(self.vec)))
     }
 }
 
@@ -359,7 +361,7 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     fn end(self) -> Result<Value<'static>> {
         let mut object = Object::with_capacity(1);
 
-        object.insert(self.name.into(), Value::Array(self.vec.into()));
+        object.insert(self.name.into(), Value::Array(RVec::from(self.vec)));
 
         Ok(Value::from(object))
     }

--- a/tremor-value/src/value.rs
+++ b/tremor-value/src/value.rs
@@ -210,6 +210,8 @@ impl<'value> PartialOrd for Value<'value> {
 }
 impl<'value> Ord for Value<'value> {
     fn cmp(&self, other: &Self) -> Ordering {
+        Ordering::Equal
+            /*
         match (self, other) {
             (Value::Static(v1), Value::Static(v2)) => Static(*v1).cmp(&Static(*v2)),
             (Value::Static(_s), _) => Ordering::Greater,
@@ -231,6 +233,7 @@ impl<'value> Ord for Value<'value> {
             // (_, Value::Array(_a)) => Ordering::Less,
             // (Value::Object(v1), Value::Object(v2)) => cmp_map(v1.as_ref(), v2.as_ref()),
         }
+        */
     }
 }
 // fn cmp_map(left: &Object, right: &Object) -> Ordering {

--- a/tremor-value/src/value/cmp.rs
+++ b/tremor-value/src/value/cmp.rs
@@ -64,25 +64,25 @@ impl<'value> PartialEq<OwnedValue> for Value<'value> {
     }
 }
 
-impl<'value> PartialEq<BorrowedValue<'value>> for Value<'value> {
-    #[inline]
-    #[must_use]
-    fn eq(&self, other: &BorrowedValue) -> bool {
-        match (self, other) {
-            (Self::Static(s1), BorrowedValue::Static(s2)) => s1 == s2,
-            (Self::String(v1), BorrowedValue::String(v2)) => v1.as_ref().eq(v2.as_ref()),
-            (Self::Array(v1), BorrowedValue::Array(v2)) => v1.eq(v2),
-            (Self::Object(v1), BorrowedValue::Object(v2)) => {
-                if v1.len() != v2.len() {
-                    return false;
-                }
-                v2.iter()
-                    .all(|(key, value)| v1.get(key.as_ref()).map_or(false, |v| v.eq(value)))
-            }
-            _ => false,
-        }
-    }
-}
+// impl<'value> PartialEq<BorrowedValue<'value>> for Value<'value> {
+//     #[inline]
+//     #[must_use]
+//     fn eq(&self, other: &BorrowedValue) -> bool {
+//         match (self, other) {
+//             // (Self::Static(s1), BorrowedValue::Static(s2)) => s1 == s2,
+//             (Self::String(v1), BorrowedValue::String(v2)) => v1.as_ref().eq(v2.as_ref()),
+//             // (Self::Array(v1), BorrowedValue::Array(v2)) => v1.eq(v2),
+//             (Self::Object(v1), BorrowedValue::Object(v2)) => {
+//                 if v1.len() != v2.len() {
+//                     return false;
+//                 }
+//                 v2.iter()
+//                     .all(|(key, value)| v1.get(key.as_ref()).map_or(false, |v| v.eq(value)))
+//             }
+//             _ => false,
+//         }
+//     }
+// }
 
 impl<'value> From<Value<'value>> for OwnedValue {
     #[inline]

--- a/tremor-value/src/value/from.rs
+++ b/tremor-value/src/value/from.rs
@@ -17,6 +17,8 @@ use beef::Cow;
 use simd_json::{BorrowedValue, OwnedValue, StaticNode};
 use std::iter::FromIterator;
 
+use abi_stable::std_types::RVec;
+
 impl<'value> From<OwnedValue> for Value<'value> {
     #[inline]
     #[must_use]
@@ -227,6 +229,17 @@ where
     #[inline]
     #[must_use]
     fn from(v: Vec<S>) -> Self {
+        v.into_iter().collect()
+    }
+}
+
+impl<'value, S> From<RVec<S>> for Value<'value>
+where
+    Value<'value>: From<S>,
+{
+    #[inline]
+    #[must_use]
+    fn from(v: RVec<S>) -> Self {
         v.into_iter().collect()
     }
 }


### PR DESCRIPTION
# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


